### PR TITLE
Enable procedural road cracks generated on regenerate

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -156,6 +156,139 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
         return { x: invA * p.x + invC * p.y, y: invB * p.x + invD * p.y };
     };
 
+    type ProceduralCrackResult = { texture: PIXI.Texture; pixelWidth: number; pixelHeight: number } | null;
+
+    const generateProceduralCrackTexture = (minX: number, minY: number, spriteW: number, spriteH: number): ProceduralCrackResult => {
+        if (typeof document === 'undefined') return null;
+        try {
+            const noiseCfg = (config as any).render.crackNoiseParams || {
+                baseScale: 1 / 480,
+                octaves: 4,
+                lacunarity: 2,
+                gain: 0.5,
+                buckets: 3,
+                crackBandWidth: 0.008,
+                maxActiveBuckets: 2,
+                activeBucketStrategy: 'smallest'
+            };
+            const seedBase = Math.floor(Math.random() * 10000);
+            const dpr = (typeof window !== 'undefined' && window.devicePixelRatio) ? window.devicePixelRatio : 1;
+            const nW = Math.max(1, Math.ceil(spriteW * dpr));
+            const nH = Math.max(1, Math.ceil(spriteH * dpr));
+            const regionRes = Math.max(64, Math.min(256, Math.floor(Math.min(nW, nH) / 8)));
+            const regionW = Math.max(1, Math.floor(nW / regionRes));
+            const regionH = Math.max(1, Math.floor(nH / regionRes));
+            const regionNoise = new Noise(seedBase);
+            const baseScale = noiseCfg.baseScale || 1 / 240;
+            const octaves = noiseCfg.octaves || 4;
+            const lacunarity = noiseCfg.lacunarity || 2;
+            const gain = noiseCfg.gain || 0.5;
+            const buckets = Math.max(1, Math.min(8, noiseCfg.buckets || 3));
+            const crackBandWidth = Math.max(0.002, Math.min(0.1, noiseCfg.crackBandWidth || 0.012));
+            const maxActive = Math.max(1, Math.min(buckets, noiseCfg.maxActiveBuckets || 2));
+            const regionMap: Uint8Array = new Uint8Array(regionW * regionH);
+            const bucketCounts = new Array(buckets).fill(0);
+
+            for (let ry = 0; ry < regionH; ry++) {
+                for (let rx = 0; rx < regionW; rx++) {
+                    const px = Math.floor((rx + 0.5) * (nW / regionW) / dpr);
+                    const py = Math.floor((ry + 0.5) * (nH / regionH) / dpr);
+                    const screenPt = { x: px + minX, y: py + minY };
+                    const worldPt = isoToWorld(screenPt);
+                    const v = fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+                    let id = Math.floor(v * buckets);
+                    if (id < 0) id = 0;
+                    if (id >= buckets) id = buckets - 1;
+                    regionMap[ry * regionW + rx] = id;
+                    bucketCounts[id]++;
+                }
+            }
+
+            const bucketAlphas: Uint8ClampedArray[] = new Array(buckets);
+            for (let b = 0; b < buckets; b++) {
+                const buf = new Uint8ClampedArray(nW * nH * 4);
+                bucketAlphas[b] = buf;
+                const n = new Noise(seedBase + b * 97 + 13);
+                const fineScale = baseScale * (1.5 + b * 0.6);
+                for (let y = 0; y < nH; y++) {
+                    for (let x = 0; x < nW; x++) {
+                        const screenPt = { x: (x / dpr) + minX, y: (y / dpr) + minY };
+                        const worldPt = isoToWorld(screenPt);
+                        const v = fbmNoise(n, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+                        const bucketCenter = (b + 0.5) / buckets;
+                        const dist = Math.abs(v - bucketCenter);
+                        const edge = Math.max(0, (crackBandWidth - dist) / crackBandWidth);
+                        const edgeSoft = Math.pow(edge, 1.2);
+                        const fine = fbmNoise(n, worldPt.x * fineScale * 3.0, worldPt.y * fineScale * 3.0, 2, 2, 0.6);
+                        const alpha = Math.round(255 * Math.max(0, Math.min(1, edgeSoft * (0.35 + 0.65 * fine))));
+                        const idx = (y * nW + x) * 4;
+                        buf[idx] = 24;
+                        buf[idx + 1] = 24;
+                        buf[idx + 2] = 24;
+                        buf[idx + 3] = alpha;
+                    }
+                }
+            }
+
+            const bucketStats = bucketCounts.map((c, i) => ({ i, c }));
+            const strategy = (noiseCfg.activeBucketStrategy || 'smallest');
+            let picked: { i: number; c: number }[] = [];
+            if (strategy === 'largest') {
+                picked = bucketStats.slice().sort((a, b) => b.c - a.c).slice(0, maxActive);
+            } else if (strategy === 'random') {
+                const arr = bucketStats.slice();
+                for (let i = arr.length - 1; i > 0; i--) {
+                    const j = Math.floor(Math.random() * (i + 1));
+                    const t = arr[i];
+                    arr[i] = arr[j];
+                    arr[j] = t;
+                }
+                picked = arr.slice(0, maxActive);
+            } else {
+                picked = bucketStats.slice().sort((a, b) => a.c - b.c).slice(0, maxActive);
+            }
+            const activeBuckets = new Set<number>(picked.map(p => p.i));
+
+            const crackCanvas = document.createElement('canvas');
+            crackCanvas.width = nW;
+            crackCanvas.height = nH;
+            const cCtx = crackCanvas.getContext('2d');
+            if (!cCtx) return null;
+            const out = cCtx.createImageData(nW, nH);
+            for (let y = 0; y < nH; y++) {
+                for (let x = 0; x < nW; x++) {
+                    const rxF = (x / nW) * regionW;
+                    const ryF = (y / nH) * regionH;
+                    const rx0 = Math.max(0, Math.min(regionW - 1, Math.floor(rxF)));
+                    const ry0 = Math.max(0, Math.min(regionH - 1, Math.floor(ryF)));
+                    const id = regionMap[ry0 * regionW + rx0];
+                    let a = 0;
+                    if (activeBuckets.has(id)) {
+                        const buf = bucketAlphas[id];
+                        const idx = (y * nW + x) * 4;
+                        a = buf ? buf[idx + 3] : 0;
+                    }
+                    const idxOut = (y * nW + x) * 4;
+                    out.data[idxOut] = 24;
+                    out.data[idxOut + 1] = 24;
+                    out.data[idxOut + 2] = 24;
+                    out.data[idxOut + 3] = a;
+                }
+            }
+            cCtx.putImageData(out, 0, 0);
+            const finalBase = new PIXI.BaseTexture(crackCanvas as any);
+            try { (finalBase as any).wrapMode = (PIXI as any).WRAP_MODES?.CLAMP ?? PIXI.WRAP_MODES.CLAMP; } catch (e) {}
+            const texture = new PIXI.Texture(finalBase);
+            try {
+                console.log('[CrackDebug] buckets:', bucketStats, 'picked:', Array.from(activeBuckets));
+            } catch (e) {}
+            return { texture, pixelWidth: nW, pixelHeight: nH };
+        } catch (err) {
+            console.warn('[GameCanvas] procedural crack generation failed', err);
+            return null;
+        }
+    };
+
     // Stable node key generator: snap coordinates to a small grid before stringifying.
     // This avoids accidental separate keys for points that should be considered the same
     // intersection due to floating point jitter. Grid size is configurable via
@@ -1946,7 +2079,9 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
             try { roadCrackSpriteRef.current = null; } catch (e) {}
             roadCrackOverlay.current?.removeChildren();
             try { console.debug('[GameCanvas] roadCrackTexture prop present=', !!roadCrackTextureRef.current, 'roadCrackOverlayChildrenBefore=', roadCrackOverlay.current?.children.length); } catch (e) {}
-            const useCrack = !!roadCrackTextureRef.current && !!(config as any).render.roadCrackUseTexture;
+            const wantProceduralCracks = !!((config as any).render.crackUseNoise) && ((config as any).render.crackAutoGenerate ?? true);
+            const manualTextureEnabled = !!roadCrackTextureRef.current && !!(config as any).render.roadCrackUseTexture;
+            const useCrack = wantProceduralCracks || manualTextureEnabled;
             if (useCrack) {
                 // Combine all road polygons into a single mask graphics to reduce draw count.
                 // First collect all polygons and compute bounding box in screen (iso) coords,
@@ -2013,230 +2148,111 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                         maskG.closePath();
                     }
                     maskG.endFill();
-                    const tex = roadCrackTextureRef.current || PIXI.Texture.WHITE;
-                    // ensure wrap mode on base texture so scaling/repeat works
-                    try {
-                        const bt = (tex as any).baseTexture;
-                        if (bt) {
-                            const applyWrap = () => {
-                                try { bt.wrapMode = PIXI.WRAP_MODES.REPEAT; } catch (e) {}
-                                try {
-                                    const sv = (typeof roadCrackScale === 'number' && isFinite(roadCrackScale)) ? Math.max(1e-6, roadCrackScale) : 1.0;
-                                    if (roadCrackSpriteRef.current && (roadCrackSpriteRef.current as any) instanceof PIXI.TilingSprite && (roadCrackSpriteRef.current as any).tileScale) (roadCrackSpriteRef.current as any).tileScale.set(sv, sv);
-                                } catch (e) {}
-                            };
-                            if (!bt.valid && typeof bt.on === 'function') {
-                                try { bt.on('update', applyWrap); } catch (e) { applyWrap(); }
-                            } else {
-                                applyWrap();
-                            }
-                        }
-                    } catch (e) {}
                     const spriteW = Math.max(4, Math.ceil(maxX - minX));
                     const spriteH = Math.max(4, Math.ceil(maxY - minY));
-                    // If noise-driven cracks are enabled, composite the crack texture with a noise mask
-                    let finalTexture: PIXI.Texture = tex;
-                    const useNoise = !!((config as any).render.crackUseNoise);
-                    const applyDirect = !!((config as any).render.crackApplyDirect);
-                    if (useNoise && typeof document !== 'undefined') {
-                        try {
-                            // Gerar rachaduras apenas em áreas delimitadas pelo ruído.
-                            const noiseCfg = (config as any).render.crackNoiseParams || { baseScale: 1/480, octaves: 4, lacunarity: 2, gain: 0.5, buckets: 3, bucketBand: 0.08, crackBandWidth: 0.008, maxActiveBuckets: 2 };
-                            const seedBase = Math.floor(Math.random() * 10000);
-                            const dpr = (typeof window !== 'undefined' && window.devicePixelRatio) ? window.devicePixelRatio : 1;
-                            const nW = Math.max(1, Math.ceil(spriteW * dpr));
-                            const nH = Math.max(1, Math.ceil(spriteH * dpr));
-                            const regionRes = Math.max(64, Math.min(256, Math.floor(Math.min(nW, nH) / 8)));
-                            const regionW = Math.max(1, Math.floor(nW / regionRes));
-                            const regionH = Math.max(1, Math.floor(nH / regionRes));
-                            const regionNoise = new Noise(seedBase);
-                            const baseScale = noiseCfg.baseScale || 1/240;
-                            const octaves = noiseCfg.octaves || 4;
-                            const lacunarity = noiseCfg.lacunarity || 2;
-                            const gain = noiseCfg.gain || 0.5;
-                            const buckets = Math.max(1, Math.min(8, noiseCfg.buckets || 3));
-                            const bucketBand = Math.max(0.01, Math.min(0.5, noiseCfg.bucketBand || 0.08));
-                            const crackBandWidth = Math.max(0.002, Math.min(0.1, noiseCfg.crackBandWidth || 0.012));
-
-                            // 1) construir mapa de regiões (quantizado)
-                            const regionMap: Uint8Array = new Uint8Array(regionW * regionH);
-                            let minV = 1, maxV = 0;
-                            for (let ry = 0; ry < regionH; ry++) {
-                                for (let rx = 0; rx < regionW; rx++) {
-                                    const px = Math.floor((rx + 0.5) * (nW / regionW) / dpr);
-                                    const py = Math.floor((ry + 0.5) * (nH / regionH) / dpr);
-                                    const sx = (px / dpr);
-                                    const sy = (py / dpr);
-                                    const screenPt = { x: sx + minX, y: sy + minY };
-                                    const worldPt = isoToWorld(screenPt);
-                                    const v = fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
-                                    if (v < minV) minV = v;
-                                    if (v > maxV) maxV = v;
-                                    let id = Math.floor(v * buckets);
-                                    if (id < 0) id = 0; if (id >= buckets) id = buckets - 1;
-                                    regionMap[ry * regionW + rx] = id;
-                                }
-                            }
-                            // 2) Para cada bucket, gerar uma textura procedural de rachadura (canvas)
-                            const bucketAlphas: Uint8ClampedArray[] = [];
-                            let totalCrackPixels = 0;
-                            for (let b = 0; b < buckets; b++) {
-                                const s = seedBase + b * 97 + 13;
-                                const n = new Noise(s);
-                                const ctxTemp = document.createElement('canvas').getContext('2d');
-                                const imgB = (ctxTemp ? ctxTemp.createImageData(nW, nH) : null);
-                                const bucketCenter = (b + 0.5) / buckets;
-                                const fineScale = baseScale * (1.5 + b * 0.6);
-                                let bucketCrackPixels = 0;
-                                if (imgB) {
-                                    for (let y = 0; y < nH; y++) {
-                                        for (let x = 0; x < nW; x++) {
-                                            const sx = (x / dpr);
-                                            const sy = (y / dpr);
-                                            const screenPt = { x: sx + minX, y: sy + minY };
-                                            const worldPt = isoToWorld(screenPt);
-                                            const v = fbmNoise(n, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
-                                            const dist = Math.abs(v - bucketCenter);
-                                            const edge = Math.max(0, (crackBandWidth - dist) / crackBandWidth);
-                                            const edgeSoft = Math.pow(edge, 1.2);
-                                            const fine = fbmNoise(n, worldPt.x * fineScale * 3.0, worldPt.y * fineScale * 3.0, 2, 2, 0.6);
-                                            const alpha = Math.round(255 * Math.max(0, Math.min(1, edgeSoft * (0.35 + 0.65 * fine))));
-                                            if (alpha > 32) bucketCrackPixels++;
-                                            const idx = (y * nW + x) * 4;
-                                            imgB.data[idx] = 24; imgB.data[idx + 1] = 24; imgB.data[idx + 2] = 24; imgB.data[idx + 3] = alpha;
-                                        }
-                                    }
-                                    bucketAlphas.push(new Uint8ClampedArray(imgB.data));
-                                } else {
-                                    bucketAlphas.push(new Uint8ClampedArray(nW * nH * 4));
-                                }
-                                totalCrackPixels += bucketCrackPixels;
-                                if (window && window.console) {
-                                    console.log(`[CrackDebug] Bucket ${b}: crack pixels >32 alpha =`, bucketCrackPixels);
-                                }
-                            }
-
-                            // Decide quais buckets estarão ativos: escolher os top-N buckets por cobertura
-                            const counts = new Array(buckets).fill(0);
-                            for (let i = 0; i < regionMap.length; i++) counts[regionMap[i]]++;
-                            const bucketStats = counts.map((c, i) => ({ i, c }));
-                            const maxActive = Math.max(1, Math.min(buckets, noiseCfg.maxActiveBuckets || 2));
-                            const strategy = (noiseCfg.activeBucketStrategy || 'smallest');
-                            let picked: { i: number; c: number }[] = [];
-                            if (strategy === 'largest') {
-                                picked = bucketStats.slice().sort((a, b) => b.c - a.c).slice(0, maxActive);
-                            } else if (strategy === 'random') {
-                                const arr = bucketStats.slice();
-                                for (let i = arr.length - 1; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); const t = arr[i]; arr[i] = arr[j]; arr[j] = t; }
-                                picked = arr.slice(0, maxActive);
-                            } else {
-                                picked = bucketStats.slice().sort((a, b) => a.c - b.c).slice(0, maxActive);
-                            }
-                            const activeBuckets = new Set<number>(picked.map(p => p.i));
-
-                            // 3) Compor final: para cada pixel do canvas final, pegar o bucket de regionMap e copiar alpha do bucket ativo
-                            const crackCanvas = document.createElement('canvas');
-                            crackCanvas.width = nW; crackCanvas.height = nH;
-                            const cCtx = crackCanvas.getContext('2d');
-                            let finalCrackPixels = 0;
-                            if (cCtx) {
-                                const out = cCtx.createImageData(nW, nH);
-                                for (let y = 0; y < nH; y++) {
-                                    for (let x = 0; x < nW; x++) {
-                                        const rxF = (x / nW) * regionW; const ryF = (y / nH) * regionH;
-                                        const rx0 = Math.max(0, Math.min(regionW - 1, Math.floor(rxF)));
-                                        const ry0 = Math.max(0, Math.min(regionH - 1, Math.floor(ryF)));
-                                        const id = regionMap[ry0 * regionW + rx0];
-                                        let a = 0;
-                                        if (activeBuckets.has(id)) {
-                                            const buf = bucketAlphas[id];
-                                            const idx = (y * nW + x) * 4;
-                                            a = buf ? buf[idx + 3] : 0;
-                                        }
-                                        if (a > 32) finalCrackPixels++;
-                                        const idxOut = (y * nW + x) * 4;
-                                        out.data[idxOut] = 24; out.data[idxOut + 1] = 24; out.data[idxOut + 2] = 24; out.data[idxOut + 3] = a;
-                                    }
-                                }
-                                cCtx.putImageData(out, 0, 0);
-                                const finalBase = new PIXI.BaseTexture(crackCanvas);
-                                try { (finalBase as any).wrapMode = (PIXI as any).WRAP_MODES?.REPEAT ?? (PIXI as any).WRAP_MODES; } catch (e) {}
-                                finalTexture = new PIXI.Texture(finalBase);
-                            }
-                            if (window && window.console) {
-                                console.log('[CrackDebug] regionMap:', { regionW, regionH, buckets, minV, maxV, counts });
-                                console.log('[CrackDebug] picked activeBuckets:', Array.from(activeBuckets));
-                                console.log('[CrackDebug] totalCrackPixels (all buckets):', totalCrackPixels, 'finalCrackPixels (composed):', finalCrackPixels);
-                            }
-                        } catch (e) {
-                            console.warn('[GameCanvas] procedural crack generation failed', e);
+                    let finalTexture: PIXI.Texture | null = null;
+                    let proceduralUsed = false;
+                    if (wantProceduralCracks) {
+                        const generated = generateProceduralCrackTexture(minX, minY, spriteW, spriteH);
+                        if (generated) {
+                            finalTexture = generated.texture;
+                            proceduralUsed = true;
                         }
                     }
-
-                    // If applying directly, create a Sprite. Otherwise use a TilingSprite as before.
-                    const sprite = applyDirect ? new PIXI.Sprite(finalTexture) : new PIXI.TilingSprite(finalTexture, spriteW, spriteH);
-                    // keep a ref so external prop changes can update tileScale/alpha in-place
-                    try { roadCrackSpriteRef.current = sprite; } catch (e) {}
-                    // apply scale safely (only for TilingSprite)
-                    try {
-                        const scaleVal = (typeof roadCrackScale === 'number' && isFinite(roadCrackScale)) ? Math.max(0.000001, roadCrackScale) : 1.0;
-                        if ((sprite as any) instanceof PIXI.TilingSprite && (sprite as any).tileScale) {
-                            try { (sprite as any).tileScale.set(scaleVal, scaleVal); } catch (e) {}
-                        }
-                        try { console.debug('[GameCanvas] roadCrack tileScale set to', scaleVal); } catch (e) {}
-                    } catch (e) {}
-                    // Apply tileTransform only for TilingSprite
-                    try {
-                        const rCfg = (config as any).render || {};
-                        const isoA = typeof rCfg.isoA === 'number' ? rCfg.isoA : 1;
-                        const isoB = typeof rCfg.isoB === 'number' ? rCfg.isoB : 0;
-                        const isoC = typeof rCfg.isoC === 'number' ? rCfg.isoC : 0;
-                        const isoD = typeof rCfg.isoD === 'number' ? rCfg.isoD : 1;
-                        if ((sprite as any) instanceof PIXI.TilingSprite && (sprite as any).tileTransform) {
+                    if (!finalTexture && manualTextureEnabled) {
+                        finalTexture = roadCrackTextureRef.current || null;
+                    }
+                    if (finalTexture) {
+                        if (!proceduralUsed) {
                             try {
-                                (sprite as any).tileTransform.a = isoA;
-                                (sprite as any).tileTransform.b = isoB;
-                                (sprite as any).tileTransform.c = isoC;
-                                (sprite as any).tileTransform.d = isoD;
-                                (sprite as any).tileTransform.tx = 0;
-                                (sprite as any).tileTransform.ty = 0;
+                                const bt = (finalTexture as any).baseTexture;
+                                if (bt) {
+                                    const applyWrap = () => {
+                                        try { bt.wrapMode = PIXI.WRAP_MODES.REPEAT; } catch (e) {}
+                                        try {
+                                            const sv = (typeof roadCrackScale === 'number' && isFinite(roadCrackScale)) ? Math.max(1e-6, roadCrackScale) : 1.0;
+                                            if (roadCrackSpriteRef.current && (roadCrackSpriteRef.current as any) instanceof PIXI.TilingSprite && (roadCrackSpriteRef.current as any).tileScale) (roadCrackSpriteRef.current as any).tileScale.set(sv, sv);
+                                        } catch (e) {}
+                                    };
+                                    if (!bt.valid && typeof bt.on === 'function') {
+                                        try { bt.on('update', applyWrap); } catch (e) { applyWrap(); }
+                                    } else {
+                                        applyWrap();
+                                    }
+                                }
                             } catch (e) {}
                         }
-                    } catch (e) {}
-                    sprite.alpha = (typeof roadCrackAlpha === 'number') ? roadCrackAlpha : 0.6;
-                    // Sprite drawn in container-local coords so place it at (0,0)
-                    sprite.x = 0; sprite.y = 0;
-                    const container = new PIXI.Container();
-                    // Position container at the bounding box origin so local mask coords align
-                    container.x = minX; container.y = minY;
-                    container.addChild(sprite);
-                    container.addChild(maskG);
-                    container.mask = maskG;
-                    roadCrackOverlay.current?.addChild(container);
-                    // Debug overlay: draw polygon outlines and bbox if requested
-                    try {
-                        if ((config as any).render && (config as any).render.debugCrackMask) {
-                            const debugG = new PIXI.Graphics();
-                            // bbox (blue)
-                            debugG.lineStyle(2, 0x0000FF, 0.8);
-                            debugG.drawRect(minX, minY, maxX - minX, maxY - minY);
-                            // mask polygons (red), draw in world coords for clarity
-                            debugG.lineStyle(1, 0xFF0000, 0.9);
-                            for (const poly of polys) {
-                                debugG.moveTo(poly[0].x, poly[0].y);
-                                for (let i = 1; i < poly.length; i++) debugG.lineTo(poly[i].x, poly[i].y);
-                                debugG.closePath();
-                            }
-                            // If we auto-increased padding, show a small green marker at the top-left
-                            if (padding > 4) {
-                                debugG.beginFill(0x00FF00, 0.9);
-                                debugG.drawCircle(minX + 6, minY + 6, 4);
-                                debugG.endFill();
-                            }
-                            roadCrackOverlay.current?.addChild(debugG);
+                        const applyDirect = proceduralUsed ? true : !!((config as any).render.crackApplyDirect);
+                        const sprite = applyDirect ? new PIXI.Sprite(finalTexture) : new PIXI.TilingSprite(finalTexture, spriteW, spriteH);
+                        if (applyDirect) {
+                            try {
+                                (sprite as PIXI.Sprite).width = spriteW;
+                                (sprite as PIXI.Sprite).height = spriteH;
+                            } catch (e) {}
                         }
-                    } catch (e) {}
-                    try { console.debug('[GameCanvas] roadCrackOverlay added container, childrenNow=', roadCrackOverlay.current?.children.length); } catch (e) {}
+                        // keep a ref so external prop changes can update tileScale/alpha in-place
+                        try { roadCrackSpriteRef.current = sprite; } catch (e) {}
+                        // apply scale safely (only for TilingSprite)
+                        try {
+                            const scaleVal = (typeof roadCrackScale === 'number' && isFinite(roadCrackScale)) ? Math.max(0.000001, roadCrackScale) : 1.0;
+                            if ((sprite as any) instanceof PIXI.TilingSprite && (sprite as any).tileScale) {
+                                try { (sprite as any).tileScale.set(scaleVal, scaleVal); } catch (e) {}
+                            }
+                            try { console.debug('[GameCanvas] roadCrack tileScale set to', scaleVal); } catch (e) {}
+                        } catch (e) {}
+                        // Apply tileTransform only for TilingSprite
+                        try {
+                            const rCfg = (config as any).render || {};
+                            const isoA = typeof rCfg.isoA === 'number' ? rCfg.isoA : 1;
+                            const isoB = typeof rCfg.isoB === 'number' ? rCfg.isoB : 0;
+                            const isoC = typeof rCfg.isoC === 'number' ? rCfg.isoC : 0;
+                            const isoD = typeof rCfg.isoD === 'number' ? rCfg.isoD : 1;
+                            if ((sprite as any) instanceof PIXI.TilingSprite && (sprite as any).tileTransform) {
+                                try {
+                                    (sprite as any).tileTransform.a = isoA;
+                                    (sprite as any).tileTransform.b = isoB;
+                                    (sprite as any).tileTransform.c = isoC;
+                                    (sprite as any).tileTransform.d = isoD;
+                                    (sprite as any).tileTransform.tx = 0;
+                                    (sprite as any).tileTransform.ty = 0;
+                                } catch (e) {}
+                            }
+                        } catch (e) {}
+                        sprite.alpha = (typeof roadCrackAlpha === 'number') ? roadCrackAlpha : 0.6;
+                        // Sprite drawn in container-local coords so place it at (0,0)
+                        sprite.x = 0; sprite.y = 0;
+                        const container = new PIXI.Container();
+                        // Position container at the bounding box origin so local mask coords align
+                        container.x = minX; container.y = minY;
+                        container.addChild(sprite);
+                        container.addChild(maskG);
+                        container.mask = maskG;
+                        roadCrackOverlay.current?.addChild(container);
+                        // Debug overlay: draw polygon outlines and bbox if requested
+                        try {
+                            if ((config as any).render && (config as any).render.debugCrackMask) {
+                                const debugG = new PIXI.Graphics();
+                                // bbox (blue)
+                                debugG.lineStyle(2, 0x0000FF, 0.8);
+                                debugG.drawRect(minX, minY, maxX - minX, maxY - minY);
+                                // mask polygons (red), draw in world coords for clarity
+                                debugG.lineStyle(1, 0xFF0000, 0.9);
+                                for (const poly of polys) {
+                                    debugG.moveTo(poly[0].x, poly[0].y);
+                                    for (let i = 1; i < poly.length; i++) debugG.lineTo(poly[i].x, poly[i].y);
+                                    debugG.closePath();
+                                }
+                                // If we auto-increased padding, show a small green marker at the top-left
+                                if (padding > 4) {
+                                    debugG.beginFill(0x00FF00, 0.9);
+                                    debugG.drawCircle(minX + 6, minY + 6, 4);
+                                    debugG.endFill();
+                                }
+                                roadCrackOverlay.current?.addChild(debugG);
+                            }
+                        } catch (e) {}
+                        try { console.debug('[GameCanvas] roadCrackOverlay added container, childrenNow=', roadCrackOverlay.current?.children.length); } catch (e) {}
+                    }
                 }
             }
         } catch (e) {

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -294,7 +294,9 @@ export const config = {
     // Pixel threshold to consider a polygon vertex 'touching' the bbox edge
     crackMaskTouchEps: 1.0,
     // Use Perlin/Fbm noise to distribute cracks instead of masking full roads
-    crackUseNoise: false,
+    crackUseNoise: true,
+    // Generate road crack textures procedurally on each regenerate
+    crackAutoGenerate: true,
     // Parâmetros para geração procedural de rachaduras via fBm/Perlin.
     // - baseScale: frequência base do ruído (1/meters). Valores maiores => manchas maiores.
     // - octaves/lacunarity/gain: parâmetros de fBm.
@@ -313,7 +315,7 @@ export const config = {
         activeBucketStrategy: 'smallest'
     },
     // If true, bake cracks directly to a sprite applied to the map (no tiling sprite mask)
-    crackApplyDirect: false,
+    crackApplyDirect: true,
     // Mostrar apenas os contornos dos quarteirões (esconde ruas e preenchimento dos prédios)
     showOnlyBlockOutlines: false,
     // Mostrar apenas o interior dos quarteirões (preenchidos), escondendo ruas e demais elementos


### PR DESCRIPTION
## Summary
- add a reusable helper that synthesizes crack textures using fBm/Perlin noise and the existing preview algorithm
- update the road overlay to auto-build procedural crack sprites during map regeneration while still supporting manual textures
- turn on noise-driven crack generation and direct sprite drawing by default in the render configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbc17e5e94832a92e60f8faf5df2aa