### PR TITLE
Implement crash mask intersection for procedural cracks

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -16,6 +16,90 @@ import NoiseZoning from '../overlays/NoiseZoning';
 import { createGrassTexture } from '../overlays/grassTexture';
 import Quadtree from '../lib/quadtree';
 import { generateCrackRaster, CrackRaster } from '../tools/crackGenerator';
+
+type XY = { x: number; y: number };
+
+interface LocalPolygon {
+    points: XY[];
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+}
+
+const pointInPolygon = (px: number, py: number, polygon: XY[]): boolean => {
+    if (polygon.length < 3) return false;
+    let inside = false;
+    for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+        const xi = polygon[i].x;
+        const yi = polygon[i].y;
+        const xj = polygon[j].x;
+        const yj = polygon[j].y;
+        const intersect = ((yi > py) !== (yj > py)) && (px < ((xj - xi) * (py - yi)) / (yj - yi) + xi);
+        if (intersect) inside = !inside;
+    }
+    return inside;
+};
+
+const buildCrashMask = (raster: CrackRaster, polygons: XY[][], originX: number, originY: number): Uint8Array | null => {
+    if (!polygons.length || raster.width <= 0 || raster.height <= 0) return null;
+
+    const localPolys: LocalPolygon[] = [];
+    for (const poly of polygons) {
+        if (!poly || poly.length < 3) continue;
+        const pts: XY[] = [];
+        let minX = Infinity;
+        let minY = Infinity;
+        let maxX = -Infinity;
+        let maxY = -Infinity;
+        for (const p of poly) {
+            const lx = p.x - originX;
+            const ly = p.y - originY;
+            pts.push({ x: lx, y: ly });
+            if (lx < minX) minX = lx;
+            if (ly < minY) minY = ly;
+            if (lx > maxX) maxX = lx;
+            if (ly > maxY) maxY = ly;
+        }
+        if (pts.length >= 3 && Number.isFinite(minX) && Number.isFinite(minY) && Number.isFinite(maxX) && Number.isFinite(maxY)) {
+            localPolys.push({ points: pts, minX, minY, maxX, maxY });
+        }
+    }
+
+    if (localPolys.length === 0) return null;
+
+    const invQuality = raster.quality > 0 ? (1 / raster.quality) : 1;
+    const fbmMask = raster.fbmMask;
+    const fbmData = fbmMask?.data ?? null;
+    const fbmW = fbmMask?.width ?? 0;
+    const fbmH = fbmMask?.height ?? 0;
+
+    const mask = new Uint8Array(raster.width * raster.height);
+    for (let y = 0; y < raster.height; y++) {
+        const sampleY = (y + 0.5) * invQuality;
+        for (let x = 0; x < raster.width; x++) {
+            const sampleX = (x + 0.5) * invQuality;
+            if (fbmData) {
+                const mx = Math.max(0, Math.min(fbmW - 1, Math.floor(sampleX)));
+                const my = Math.max(0, Math.min(fbmH - 1, Math.floor(sampleY)));
+                if (fbmData[my * fbmW + mx] === 0) continue;
+            }
+            let inside = false;
+            for (const poly of localPolys) {
+                if (sampleX < poly.minX || sampleX > poly.maxX || sampleY < poly.minY || sampleY > poly.maxY) continue;
+                if (pointInPolygon(sampleX, sampleY, poly.points)) {
+                    inside = true;
+                    break;
+                }
+            }
+            if (inside) {
+                mask[y * raster.width + x] = 255;
+            }
+        }
+    }
+
+    return mask;
+};
 // ClipperLib (sem typings completos) - usar require para acessar classes
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const ClipperLib: any = require('clipper-lib');
@@ -1993,6 +2077,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
             const useProceduralCracks = !!renderCfg.crackUseProcedural;
             const textureFromProps = roadCrackTextureRef.current;
             const allowTexture = !!renderCfg.roadCrackUseTexture;
+            const crashMaskEnabled = !!renderCfg.crashMaskEnabled;
             const shouldRenderCracks = useProceduralCracks || (allowTexture && !!textureFromProps);
             try { console.debug('[GameCanvas] crack overlay -> procedural=', useProceduralCracks, 'hasTexture=', !!textureFromProps, 'allowTexture=', allowTexture); } catch (e) {}
             if (shouldRenderCracks) {
@@ -2068,6 +2153,26 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                             isoToWorld,
                         });
                         if (raster) {
+                            if (crashMaskEnabled) {
+                                const crashMaskData = buildCrashMask(raster, polys, minX, minY);
+                                if (crashMaskData) {
+                                    const arr = raster.data;
+                                    for (let i = 0; i < crashMaskData.length; i++) {
+                                        if (crashMaskData[i] === 0) {
+                                            const idx = i * 4;
+                                            arr[idx + 3] = 0;
+                                        }
+                                    }
+                                    raster.crashMask = {
+                                        data: crashMaskData,
+                                        width: raster.width,
+                                        height: raster.height,
+                                        minX,
+                                        minY,
+                                        quality: raster.quality,
+                                    };
+                                }
+                            }
                             const alphaMultiplier = (typeof roadCrackAlpha === 'number' && isFinite(roadCrackAlpha)) ? roadCrackAlpha : 1;
                             const graphics = rasterToGraphics(raster, spriteW, spriteH, alphaMultiplier);
                             if (graphics) {

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -287,6 +287,7 @@ export const config = {
     showBlockOutlines: true,
     // Crack mask debug/padding controls (UI-adjustable)
     debugCrackMask: false,
+    crashMaskEnabled: false,
     // Show FBM delimitations (separate toggle for fBm regions / buckets)
     showFbmDelimitations: false,
     // Default padding (px) used for crack mask bounding boxes

--- a/src/tools/crackGenerator.ts
+++ b/src/tools/crackGenerator.ts
@@ -173,6 +173,21 @@ export interface CrackRaster {
         minY: number;
         quality: number;
     };
+    fbmMask?: {
+        data: Uint8Array;
+        width: number;
+        height: number;
+        minX: number;
+        minY: number;
+    };
+    crashMask?: {
+        data: Uint8Array;
+        width: number;
+        height: number;
+        minX: number;
+        minY: number;
+        quality: number;
+    };
 }
 
 export interface CrackRasterOptions {
@@ -300,6 +315,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     let debug_regionCellW = 0;
     let debug_regionCellH = 0;
     let debug_buckets = 0;
+    let fbmMaskFull: Uint8Array | null = null;
     const attachDebugRegionRequested = !!(renderConfig && renderConfig.showFbmDelimitations);
 
     if (renderConfig?.crackUseNoise) {
@@ -400,7 +416,6 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
         // Pre-generate an FBM mask at the original render resolution (width x height)
         // and sample it per-canvas pixel. This avoids subtle coordinate mismatches
         // between canvas-res sampling and the coarse region map used below.
-        let fbmMaskFull: Uint8Array | null = null;
         try {
             fbmMaskFull = generateFbmMask({
                 width: width,
@@ -510,6 +525,15 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     }
 
     const out: CrackRaster = { data, width: canvasW, height: canvasH, quality, color: [24, 24, 24] };
+    if (fbmMaskFull) {
+        out.fbmMask = {
+            data: fbmMaskFull,
+            width,
+            height,
+            minX,
+            minY,
+        };
+    }
     if (attachDebugRegionRequested && debug_regionMap) {
         out.debugRegion = {
             map: debug_regionMap,


### PR DESCRIPTION
## Summary
- add a render config default for enabling the crash mask feature
- expose the FBM mask data from the crack generator to support downstream masking
- compute and apply the crash mask intersection when generating procedural road cracks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc52042c48832aa62b3c482de178a5