### PR TITLE
Add crash mask overlay for procedural cracks

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -15,7 +15,7 @@ import type { Point } from '../generic_modules/math';
 import NoiseZoning from '../overlays/NoiseZoning';
 import { createGrassTexture } from '../overlays/grassTexture';
 import Quadtree from '../lib/quadtree';
-import { generateCrackRaster, CrackRaster } from '../tools/crackGenerator';
+import { generateCrackRaster, CrackRaster, RasterData } from '../tools/crackGenerator';
 // ClipperLib (sem typings completos) - usar require para acessar classes
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const ClipperLib: any = require('clipper-lib');
@@ -68,6 +68,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
     const roadLaneOverlay = useRef<PIXI.Container | null>(null);
     const roadLaneOutlines = useRef<PIXI.Container | null>(null);
     const edgeOverlay = useRef<PIXI.Container | null>(null);
+    const crashMaskOverlay = useRef<PIXI.Container | null>(null);
     const roadLaneTextureRef = useRef<PIXI.Texture | null>(roadLaneTexture || null);
     const roadCrackTextureRef = useRef<PIXI.Texture | null>(roadCrackTexture || null);
     const edgeTextureRef = useRef<PIXI.Texture | null>(edgeTexture || null);
@@ -142,7 +143,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
         return { x: invA * p.x + invC * p.y, y: invB * p.x + invD * p.y };
     };
 
-    const rasterToGraphics = (raster: CrackRaster | null, spriteW: number, spriteH: number, alphaMultiplier: number): PIXI.Graphics | null => {
+    const rasterToGraphics = (raster: RasterData | null, spriteW: number, spriteH: number, alphaMultiplier: number): PIXI.Graphics | null => {
         if (!raster || raster.width <= 0 || raster.height <= 0) return null;
         const { data, width, height, color } = raster;
         if (!data || data.length === 0) return null;
@@ -1984,6 +1985,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
         // Aplicar overlay de rachaduras nas vias se houver textura definida
         try {
             roadCrackOverlay.current?.removeChildren();
+            crashMaskOverlay.current?.removeChildren();
             if (proceduralCrackGraphicsRef.current) {
                 try { proceduralCrackGraphicsRef.current.destroy(true); } catch (e) {}
                 proceduralCrackGraphicsRef.current = null;
@@ -2041,22 +2043,29 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                     maxX = Math.ceil(maxX) + padding;
                     maxY = Math.ceil(maxY) + padding;
 
-                    const maskG = new PIXI.Graphics();
-                    maskG.beginFill(0xFFFFFF);
-                    for (const poly of polys) {
-                        const local0 = { x: poly[0].x - minX, y: poly[0].y - minY };
-                        maskG.moveTo(local0.x, local0.y);
-                        for (let i = 1; i < poly.length; i++) {
-                            const lp = { x: poly[i].x - minX, y: poly[i].y - minY };
-                            maskG.lineTo(lp.x, lp.y);
+                    const buildMaskGraphics = () => {
+                        const g = new PIXI.Graphics();
+                        g.beginFill(0xFFFFFF);
+                        for (const poly of polys) {
+                            if (!poly.length) continue;
+                            const local0 = { x: poly[0].x - minX, y: poly[0].y - minY };
+                            g.moveTo(local0.x, local0.y);
+                            for (let i = 1; i < poly.length; i++) {
+                                const lp = { x: poly[i].x - minX, y: poly[i].y - minY };
+                                g.lineTo(lp.x, lp.y);
+                            }
+                            g.closePath();
                         }
-                        maskG.closePath();
-                    }
-                    maskG.endFill();
+                        g.endFill();
+                        return g;
+                    };
+
+                    const maskG = buildMaskGraphics();
 
                     const spriteW = Math.max(4, Math.ceil(maxX - minX));
                     const spriteH = Math.max(4, Math.ceil(maxY - minY));
                     let cracksDisplay: PIXI.DisplayObject | null = null;
+                    let rasterResult: CrackRaster | null = null;
 
                     if (useProceduralCracks) {
                         const raster = generateCrackRaster({
@@ -2067,6 +2076,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                             renderConfig: renderCfg,
                             isoToWorld,
                         });
+                        rasterResult = raster;
                         if (raster) {
                             const alphaMultiplier = (typeof roadCrackAlpha === 'number' && isFinite(roadCrackAlpha)) ? roadCrackAlpha : 1;
                             const graphics = rasterToGraphics(raster, spriteW, spriteH, alphaMultiplier);
@@ -2121,6 +2131,25 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                         }
                         if (typeof roadCrackAlpha === 'number') sprite.alpha = roadCrackAlpha;
                         cracksDisplay = sprite;
+                    }
+
+                    if (renderCfg.crashMaskEnabled && rasterResult?.crashOverlay) {
+                        try {
+                            const crashGraphics = rasterToGraphics(rasterResult.crashOverlay, spriteW, spriteH, 1);
+                            if (crashGraphics) {
+                                crashGraphics.alpha = 0.9;
+                                const crashContainer = new PIXI.Container();
+                                crashContainer.x = minX;
+                                crashContainer.y = minY;
+                                crashGraphics.x = 0;
+                                crashGraphics.y = 0;
+                                crashContainer.addChild(crashGraphics);
+                                const crashMaskG = buildMaskGraphics();
+                                crashContainer.addChild(crashMaskG);
+                                crashContainer.mask = crashMaskG;
+                                crashMaskOverlay.current?.addChild(crashContainer);
+                            }
+                        } catch (e) {}
                     }
 
                     if (cracksDisplay) {
@@ -3102,6 +3131,8 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
     roadCrackOverlay.current = new PIXI.Container();
     // crack overlay should sit below block edge bands so borders render on top
     (roadCrackOverlay.current as any).zIndex = 50;
+    crashMaskOverlay.current = new PIXI.Container();
+    (crashMaskOverlay.current as any).zIndex = 51;
     roadLaneOverlay.current = new PIXI.Container();
     // lane overlay should sit above lane outlines so marker texture appears above outlines, but still below crack overlay
     (roadLaneOverlay.current as any).zIndex = 41;
@@ -3139,6 +3170,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
     drawables.current.addChild(edgeOverlay.current);
     // overlay de rachaduras acima do fill das ruas e abaixo das bandas/perfis
     drawables.current.addChild(roadCrackOverlay.current);
+    drawables.current.addChild(crashMaskOverlay.current);
     // faixa das vias (linhas/texture) - acima das rachaduras
     drawables.current.addChild(roadLaneOverlay.current);
     // linhas de contorno das faixas

--- a/src/tools/crackGenerator.ts
+++ b/src/tools/crackGenerator.ts
@@ -155,12 +155,23 @@ export function generateVoronoiCrackImage(width: number, height: number, options
     return data;
 }
 
-export interface CrackRaster {
+export interface RasterData {
     data: Uint8ClampedArray;
     width: number;
     height: number;
     quality: number;
     color: [number, number, number];
+}
+
+export interface CrashMaskInfo {
+    data: Uint8Array;
+    width: number;
+    height: number;
+    minX: number;
+    minY: number;
+}
+
+export interface CrackRaster extends RasterData {
     // Optional debug info for FBM region visualization
     debugRegion?: {
         map: Uint8Array;
@@ -173,6 +184,10 @@ export interface CrackRaster {
         minY: number;
         quality: number;
     };
+    // Binary crash mask (intersection of debug mask and active buckets)
+    crashMask?: CrashMaskInfo;
+    // Procedural crash overlay rendered within the crash mask
+    crashOverlay?: RasterData;
 }
 
 export interface CrackRasterOptions {
@@ -302,6 +317,9 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     let debug_buckets = 0;
     const attachDebugRegionRequested = !!(renderConfig && renderConfig.showFbmDelimitations);
 
+    const wantsCrashMask = !!(renderConfig && renderConfig.crashMaskEnabled);
+    const crashMaskArr = wantsCrashMask ? new Uint8Array(width * height) : null;
+
     if (renderConfig?.crackUseNoise) {
         const noiseCfg = renderConfig.crackNoiseParams || { baseScale: 1 / 480, octaves: 4, lacunarity: 2, gain: 0.5, buckets: 3, crackBandWidth: 0.012, maxActiveBuckets: 2, activeBucketStrategy: 'smallest' };
         const baseScale = noiseCfg.baseScale || 1 / 480;
@@ -424,6 +442,17 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             fbmMaskFull = null;
         }
 
+        const palette = [
+            [220, 38, 38],    // vermelho
+            [34, 197, 94],    // verde
+            [37, 99, 235],    // azul
+            [234, 179, 8],    // amarelo
+            [168, 85, 247],   // roxo
+            [16, 185, 129],   // teal
+            [251, 191, 36],   // laranja
+            [244, 63, 94],    // rosa
+        ];
+
         for (let y = 0; y < canvasH; y++) {
             for (let x = 0; x < canvasW; x++) {
                 const idx = (y * canvasW + x) * 4;
@@ -431,59 +460,60 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 if (alpha === 0) continue;
                 const screenX = (x + 0.5) * invQuality;
                 const screenY = (y + 0.5) * invQuality;
-                // If we have a full-resolution FBM mask, sample it in screen coords
-                // (mask was generated at original `width`/`height`). If mask says
-                // 'blocked', clear alpha and skip per-bucket checks.
-                if (fbmMaskFull) {
-                    const mx = Math.max(0, Math.min(width - 1, Math.floor(screenX)));
-                    const my = Math.max(0, Math.min(height - 1, Math.floor(screenY)));
-                    if (fbmMaskFull[my * width + mx] === 0) {
-                        data[idx + 3] = 0;
-                        continue;
+                const mx = Math.max(0, Math.min(width - 1, Math.floor(screenX)));
+                const my = Math.max(0, Math.min(height - 1, Math.floor(screenY)));
+                const maskIdx = my * width + mx;
+
+                let passesMask = true;
+                if (fbmMaskFull && fbmMaskFull[maskIdx] === 0) {
+                    passesMask = false;
+                }
+
+                let bucketId = -1;
+                if (passesMask) {
+                    const rx = Math.max(0, Math.min(debug_regionW - 1, Math.floor(screenX / (debug_regionCellW || 1))));
+                    const ry = Math.max(0, Math.min(debug_regionH - 1, Math.floor(screenY / (debug_regionCellH || 1))));
+                    bucketId = debug_regionMap![ry * debug_regionW + rx];
+                    if (!activeBuckets.has(bucketId)) {
+                        passesMask = false;
                     }
                 }
-                const rx = Math.max(0, Math.min(debug_regionW - 1, Math.floor(screenX / (debug_regionCellW || 1))));
-                const ry = Math.max(0, Math.min(debug_regionH - 1, Math.floor(screenY / (debug_regionCellH || 1))));
-                const bucketId = debug_regionMap![ry * debug_regionW + rx];
-                if (!activeBuckets.has(bucketId)) {
+
+                if (passesMask && bucketId >= 0) {
+                    const noiseInst = bucketNoise[bucketId];
+                    const samplePt = { x: screenX + minX, y: screenY + minY };
+                    const worldPt = (renderConfig && renderConfig.mode === 'isometric')
+                        ? { x: samplePt.x, y: samplePt.y }
+                        : isoToWorld(samplePt);
+                    const baseVal = fbmNoise(noiseInst, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+                    const dist = Math.abs(baseVal - bucketCenters[bucketId]);
+                    if (dist > crackBandWidth) {
+                        passesMask = false;
+                    } else {
+                        const edge = Math.max(0, (crackBandWidth - dist) / crackBandWidth);
+                        const edgeSoft = Math.pow(edge, 1.2);
+                        const fine = fbmNoise(noiseInst, worldPt.x * fineScales[bucketId] * 3.0, worldPt.y * fineScales[bucketId] * 3.0, 2, 2, 0.6);
+                        const modulation = Math.max(0, Math.min(1, edgeSoft * (0.35 + 0.65 * fine)));
+                        const newAlpha = Math.round(alpha * modulation);
+                        if (newAlpha < 12) {
+                            passesMask = false;
+                        } else {
+                            data[idx + 3] = newAlpha;
+                            const color = palette[bucketId % palette.length];
+                            data[idx] = color[0];
+                            data[idx + 1] = color[1];
+                            data[idx + 2] = color[2];
+                        }
+                    }
+                }
+
+                if (!passesMask) {
                     data[idx + 3] = 0;
                     continue;
                 }
-                const noiseInst = bucketNoise[bucketId];
-                const samplePt = { x: screenX + minX, y: screenY + minY };
-                const worldPt = (renderConfig && renderConfig.mode === 'isometric')
-                    ? { x: samplePt.x, y: samplePt.y }
-                    : isoToWorld(samplePt);
-                const baseVal = fbmNoise(noiseInst, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
-                const dist = Math.abs(baseVal - bucketCenters[bucketId]);
-                if (dist > crackBandWidth) {
-                    data[idx + 3] = 0;
-                    continue;
-                }
-                const edge = Math.max(0, (crackBandWidth - dist) / crackBandWidth);
-                const edgeSoft = Math.pow(edge, 1.2);
-                const fine = fbmNoise(noiseInst, worldPt.x * fineScales[bucketId] * 3.0, worldPt.y * fineScales[bucketId] * 3.0, 2, 2, 0.6);
-                const modulation = Math.max(0, Math.min(1, edgeSoft * (0.35 + 0.65 * fine)));
-                const newAlpha = Math.round(alpha * modulation);
-                if (newAlpha < 12) {
-                    data[idx + 3] = 0;
-                } else {
-                    data[idx + 3] = newAlpha;
-                    // Paleta simples para buckets: cores bem distintas
-                    const palette = [
-                        [220, 38, 38],    // vermelho
-                        [34, 197, 94],    // verde
-                        [37, 99, 235],    // azul
-                        [234, 179, 8],    // amarelo
-                        [168, 85, 247],   // roxo
-                        [16, 185, 129],   // teal
-                        [251, 191, 36],   // laranja
-                        [244, 63, 94],    // rosa
-                    ];
-                    const color = palette[bucketId % palette.length];
-                    data[idx] = color[0];
-                    data[idx + 1] = color[1];
-                    data[idx + 2] = color[2];
+
+                if (crashMaskArr && bucketId >= 0) {
+                    crashMaskArr[maskIdx] = 255;
                 }
             }
         }
@@ -510,6 +540,45 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     }
 
     const out: CrackRaster = { data, width: canvasW, height: canvasH, quality, color: [24, 24, 24] };
+
+    if (crashMaskArr) {
+        let anyCrash = false;
+        for (let i = 0; i < crashMaskArr.length; i++) {
+            if (crashMaskArr[i] !== 0) { anyCrash = true; break; }
+        }
+        if (anyCrash) {
+            out.crashMask = { data: crashMaskArr, width, height, minX, minY };
+            try {
+                const crashSeed = (seed ^ 0xA5A5A5A5) >>> 0;
+                const crashImage = generateVoronoiCrackImage(width, height, {
+                    divisions: Math.max(100, Math.min(5000, crackCfg.crashDivisions || 600)),
+                    thickness: 6,
+                    dilateRadius: 0,
+                    seed: crashSeed,
+                    scale: 1,
+                    color: [0, 229, 255],
+                });
+                for (let i = 0; i < crashImage.length; i += 4) {
+                    const maskValue = crashMaskArr[i / 4];
+                    if (!maskValue) {
+                        crashImage[i] = 0;
+                        crashImage[i + 1] = 0;
+                        crashImage[i + 2] = 0;
+                        crashImage[i + 3] = 0;
+                    }
+                }
+                out.crashOverlay = {
+                    data: crashImage,
+                    width,
+                    height,
+                    quality: 1,
+                    color: [0, 229, 255],
+                };
+            } catch (e) {
+                // crash overlay is optional; ignore failures to keep cracks rendering
+            }
+        }
+    }
     if (attachDebugRegionRequested && debug_regionMap) {
         out.debugRegion = {
             map: debug_regionMap,


### PR DESCRIPTION
## Summary
- expose reusable raster metadata for crack outputs and extend crack rasters with optional crash-mask data
- capture crash-mask pixels during FBM filtering and generate a cyan Voronoi overlay limited to the mask
- render the crash overlay in the canvas with a dedicated container that shares the road mask clipping

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc52042c48832aa62b3c482de178a5