### PR TITLE
Add crash mask debug visualization

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -72,6 +72,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
     const roadCrackTextureRef = useRef<PIXI.Texture | null>(roadCrackTexture || null);
     const edgeTextureRef = useRef<PIXI.Texture | null>(edgeTexture || null);
     const proceduralCrackGraphicsRef = useRef<PIXI.Graphics | null>(null);
+    const crashMaskDebugSpriteRef = useRef<PIXI.Sprite | null>(null);
     // Cache para evitar reconstruções pesadas dos marcadores/mascara quando nada mudou
     const laneMarkerCacheRef = useRef<{ key: string; container: PIXI.Container | null } | null>(null);
     const roadLaneScaleRef = useRef<number | undefined>(roadLaneScale);
@@ -1989,6 +1990,15 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                 proceduralCrackGraphicsRef.current = null;
             }
             roadCrackDisplayRef.current = null;
+            if (crashMaskDebugSpriteRef.current) {
+                try {
+                    if (crashMaskDebugSpriteRef.current.parent) {
+                        crashMaskDebugSpriteRef.current.parent.removeChild(crashMaskDebugSpriteRef.current);
+                    }
+                    crashMaskDebugSpriteRef.current.destroy({ texture: true, baseTexture: true });
+                } catch (e) {}
+                crashMaskDebugSpriteRef.current = null;
+            }
             const renderCfg = (config as any).render || {};
             const useProceduralCracks = !!renderCfg.crackUseProcedural;
             const textureFromProps = roadCrackTextureRef.current;
@@ -2057,9 +2067,10 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                     const spriteW = Math.max(4, Math.ceil(maxX - minX));
                     const spriteH = Math.max(4, Math.ceil(maxY - minY));
                     let cracksDisplay: PIXI.DisplayObject | null = null;
+                    let crashRaster: CrackRaster | null = null;
 
                     if (useProceduralCracks) {
-                        const raster = generateCrackRaster({
+                        const rasterResult = generateCrackRaster({
                             width: spriteW,
                             height: spriteH,
                             minX,
@@ -2067,9 +2078,10 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                             renderConfig: renderCfg,
                             isoToWorld,
                         });
-                        if (raster) {
+                        if (rasterResult) {
+                            crashRaster = rasterResult;
                             const alphaMultiplier = (typeof roadCrackAlpha === 'number' && isFinite(roadCrackAlpha)) ? roadCrackAlpha : 1;
-                            const graphics = rasterToGraphics(raster, spriteW, spriteH, alphaMultiplier);
+                            const graphics = rasterToGraphics(rasterResult, spriteW, spriteH, alphaMultiplier);
                             if (graphics) {
                                 cracksDisplay = graphics;
                                 proceduralCrackGraphicsRef.current = graphics;
@@ -2133,6 +2145,33 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                         container.addChild(maskG);
                         container.mask = maskG;
                         roadCrackOverlay.current?.addChild(container);
+
+                        if (renderCfg.debugCrackMask && crashRaster?.crashMask) {
+                            try {
+                                const maskInfo = crashRaster.crashMask;
+                                const maskData = maskInfo.data;
+                                const maskW = maskInfo.width;
+                                const maskH = maskInfo.height;
+                                if (maskData && maskW > 0 && maskH > 0) {
+                                    const rgba = new Uint8Array(maskW * maskH * 4);
+                                    for (let i = 0; i < maskData.length; i++) {
+                                        const a = maskData[i];
+                                        if (!a) continue;
+                                        const ii = i * 4;
+                                        rgba[ii] = 0;
+                                        rgba[ii + 1] = 229;
+                                        rgba[ii + 2] = 255;
+                                        rgba[ii + 3] = 120;
+                                    }
+                                    const tex = PIXI.Texture.fromBuffer(rgba, maskW, maskH);
+                                    const sprite = new PIXI.Sprite(tex);
+                                    sprite.x = maskInfo.minX;
+                                    sprite.y = maskInfo.minY;
+                                    crashMaskDebugSpriteRef.current = sprite;
+                                    roadCrackOverlay.current?.addChild(sprite);
+                                }
+                            } catch (e) {}
+                        }
 
                         if (cracksDisplay instanceof PIXI.TilingSprite || cracksDisplay instanceof PIXI.Sprite) {
                             roadCrackDisplayRef.current = cracksDisplay;

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -286,6 +286,7 @@ export const config = {
     // Mostrar contornos dos quarteirões
     showBlockOutlines: true,
     // Crack mask debug/padding controls (UI-adjustable)
+    crashMaskEnabled: true,
     debugCrackMask: false,
     // Show FBM delimitations (separate toggle for fBm regions / buckets)
     showFbmDelimitations: false,

--- a/src/tools/crackGenerator.ts
+++ b/src/tools/crackGenerator.ts
@@ -161,6 +161,14 @@ export interface CrackRaster {
     height: number;
     quality: number;
     color: [number, number, number];
+    crashMask?: {
+        data: Uint8Array;
+        width: number;
+        height: number;
+        minX: number;
+        minY: number;
+        quality: number;
+    };
     // Optional debug info for FBM region visualization
     debugRegion?: {
         map: Uint8Array;
@@ -302,6 +310,10 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     let debug_buckets = 0;
     const attachDebugRegionRequested = !!(renderConfig && renderConfig.showFbmDelimitations);
 
+    const invQuality = 1 / quality;
+    const crashMaskRequested = !!(renderConfig?.crashMaskEnabled || renderConfig?.debugCrackMask);
+    const crashMaskData = crashMaskRequested ? new Uint8Array(width * height) : null;
+
     if (renderConfig?.crackUseNoise) {
         const noiseCfg = renderConfig.crackNoiseParams || { baseScale: 1 / 480, octaves: 4, lacunarity: 2, gain: 0.5, buckets: 3, crackBandWidth: 0.012, maxActiveBuckets: 2, activeBucketStrategy: 'smallest' };
         const baseScale = noiseCfg.baseScale || 1 / 480;
@@ -340,6 +352,14 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 counts[id]++;
             }
         }
+
+        try {
+            if (renderConfig) {
+                const bucketStats: Record<number, number> = {};
+                counts.forEach((c, i) => { bucketStats[i] = c; });
+                (renderConfig as any).detectedFbmBuckets = bucketStats;
+            }
+        } catch (e) {}
 
         const stats = counts.map((c, i) => ({ i, c }));
         let picked: { i: number; c: number }[] = [];
@@ -393,7 +413,6 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             fineScales[b] = baseScale * (1.5 + b * 0.6);
         }
 
-    const invQuality = 1 / quality;
     debug_regionCellW = debug_regionW > 0 ? width / debug_regionW : width;
     debug_regionCellH = debug_regionH > 0 ? height / debug_regionH : height;
     debug_buckets = buckets;
@@ -431,6 +450,12 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 if (alpha === 0) continue;
                 const screenX = (x + 0.5) * invQuality;
                 const screenY = (y + 0.5) * invQuality;
+                let crashMaskIndex = -1;
+                if (crashMaskData) {
+                    const mx = Math.max(0, Math.min(width - 1, Math.floor(screenX)));
+                    const my = Math.max(0, Math.min(height - 1, Math.floor(screenY)));
+                    crashMaskIndex = my * width + mx;
+                }
                 // If we have a full-resolution FBM mask, sample it in screen coords
                 // (mask was generated at original `width`/`height`). If mask says
                 // 'blocked', clear alpha and skip per-bucket checks.
@@ -484,6 +509,9 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                     data[idx] = color[0];
                     data[idx + 1] = color[1];
                     data[idx + 2] = color[2];
+                    if (crashMaskData && crashMaskIndex >= 0) {
+                        crashMaskData[crashMaskIndex] = 255;
+                    }
                 }
             }
         }
@@ -509,7 +537,39 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
         }
     }
 
+    if (crashMaskData) {
+        // If no pixels were marked (e.g. crash mask requested but noise disabled), derive mask from final alpha buffer.
+        let hasMaskPixel = false;
+        for (let i = 0; i < crashMaskData.length; i++) {
+            if (crashMaskData[i]) { hasMaskPixel = true; break; }
+        }
+        if (!hasMaskPixel) {
+            for (let y = 0; y < canvasH; y++) {
+                for (let x = 0; x < canvasW; x++) {
+                    const idx = (y * canvasW + x) * 4;
+                    if (data[idx + 3] > 0) {
+                        const screenX = (x + 0.5) * invQuality;
+                        const screenY = (y + 0.5) * invQuality;
+                        const mx = Math.max(0, Math.min(width - 1, Math.floor(screenX)));
+                        const my = Math.max(0, Math.min(height - 1, Math.floor(screenY)));
+                        crashMaskData[my * width + mx] = 255;
+                    }
+                }
+            }
+        }
+    }
+
     const out: CrackRaster = { data, width: canvasW, height: canvasH, quality, color: [24, 24, 24] };
+    if (crashMaskData) {
+        out.crashMask = {
+            data: crashMaskData,
+            width,
+            height,
+            minX,
+            minY,
+            quality: 1,
+        };
+    }
     if (attachDebugRegionRequested && debug_regionMap) {
         out.debugRegion = {
             map: debug_regionMap,


### PR DESCRIPTION
## Summary
- enable crash mask usage in the runtime config by default
- extend the procedural crack raster to return crash mask coverage and bucket stats for debugging
- render a cyan crash mask overlay in the PIXI road overlay when crack mask debug mode is active

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc52042c48832aa62b3c482de178a5