### PR TITLE
Refine crash mask to follow procedural cracks

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -444,7 +444,9 @@ const App: React.FC = () => {
             <GameCanvas interiorTexture={interiorTexture} interiorTextureScale={texScale} interiorTextureAlpha={texAlpha} interiorTextureTint={parseInt(texTint.slice(1),16)} crossfadeEnabled={crossfadeEnabled} crossfadeMs={crossfadeMs}
                 roadCrackTexture={roadCrackTexture} roadCrackScale={crackScale} roadCrackAlpha={crackAlpha}
                 edgeTexture={edgeTexture} edgeScale={edgeScale} edgeAlpha={edgeAlpha}
-                roadLaneTexture={laneTexture} roadLaneScale={laneScale} roadLaneAlpha={laneAlpha} />
+                roadLaneTexture={laneTexture} roadLaneScale={laneScale} roadLaneAlpha={laneAlpha}
+                crashMaskEnabled={crashMaskEnabled}
+            />
             <div id="control-bar" className={controlsCollapsed ? 'collapsed' : ''}>
                 <button id="control-bar-toggle" onClick={() => setControlsCollapsed(c => !c)} style={{ marginRight: 8 }}>
                     {controlsCollapsed ? 'Expandir' : 'Colapsar'}

--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -40,9 +40,10 @@ interface GameCanvasPropsInternal extends GameCanvasProps {
     roadLaneTexture?: PIXI.Texture | null;
     roadLaneScale?: number;
     roadLaneAlpha?: number;
+    crashMaskEnabled?: boolean;
 }
 
-const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interiorTextureScale, interiorTextureAlpha, interiorTextureTint, crossfadeEnabled, crossfadeMs, roadCrackTexture, roadCrackScale, roadCrackAlpha, edgeTexture, edgeScale, edgeAlpha, roadLaneTexture, roadLaneScale, roadLaneAlpha }) => {
+const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interiorTextureScale, interiorTextureAlpha, interiorTextureTint, crossfadeEnabled, crossfadeMs, roadCrackTexture, roadCrackScale, roadCrackAlpha, edgeTexture, edgeScale, edgeAlpha, roadLaneTexture, roadLaneScale, roadLaneAlpha, crashMaskEnabled }) => {
     const canvasContainerRef = useRef<HTMLDivElement>(null);
     const pixiRenderer = useRef<PIXI.IRenderer<PIXI.ICanvas> | null>(null);
     const stage = useRef<PIXI.Container | null>(null);
@@ -91,6 +92,9 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
     useEffect(() => {
         try { onMapChange(false); } catch (e) {}
     }, [roadCrackTexture, edgeTexture, roadCrackScale, roadCrackAlpha]);
+    useEffect(() => {
+        try { onMapChange(false); } catch (e) {}
+    }, [crashMaskEnabled]);
     useEffect(() => {
         try { roadLaneScaleRef.current = roadLaneScale; } catch (e) {}
     }, [roadLaneScale]);
@@ -195,6 +199,91 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
         }
 
         return graphics;
+    };
+
+    const maskToGraphics = (
+        mask: Uint8Array | null,
+        maskWidth: number,
+        maskHeight: number,
+        spriteW: number,
+        spriteH: number,
+        color: number,
+        alpha: number
+    ): PIXI.Graphics | null => {
+        if (!mask || maskWidth <= 0 || maskHeight <= 0) return null;
+        const finalAlpha = Math.max(0, Math.min(1, alpha));
+        if (finalAlpha <= 0) return null;
+        const stepX = spriteW / maskWidth;
+        const stepY = spriteH / maskHeight;
+        const g = new PIXI.Graphics();
+        let drew = false;
+        for (let y = 0; y < maskHeight; y++) {
+            let runStart = -1;
+            for (let x = 0; x <= maskWidth; x++) {
+                const val = x < maskWidth ? mask[y * maskWidth + x] : 0;
+                if (val > 0) {
+                    if (runStart === -1) runStart = x;
+                } else if (runStart !== -1) {
+                    const runLen = x - runStart;
+                    if (runLen > 0) {
+                        g.beginFill(color, finalAlpha);
+                        g.drawRect(runStart * stepX, y * stepY, runLen * stepX, stepY);
+                        g.endFill();
+                        drew = true;
+                    }
+                    runStart = -1;
+                }
+            }
+        }
+        if (!drew) {
+            try { g.destroy(); } catch (e) {}
+            return null;
+        }
+        return g;
+    };
+
+    const buildPolygonMask = (
+        polygons: { x: number; y: number }[][],
+        width: number,
+        height: number,
+        minX: number,
+        minY: number
+    ): Uint8Array | null => {
+        if (!polygons.length || width <= 0 || height <= 0) return null;
+        const mask = new Uint8Array(width * height);
+        const prepared = polygons.map(poly => {
+            let pMinX = Infinity, pMaxX = -Infinity, pMinY = Infinity, pMaxY = -Infinity;
+            for (const v of poly) {
+                if (v.x < pMinX) pMinX = v.x;
+                if (v.x > pMaxX) pMaxX = v.x;
+                if (v.y < pMinY) pMinY = v.y;
+                if (v.y > pMaxY) pMaxY = v.y;
+            }
+            return {
+                bounds: { minX: pMinX, maxX: pMaxX, minY: pMinY, maxY: pMaxY },
+                polygon: { vertices: poly } as blockGeometry.Polygon,
+            };
+        });
+        for (const entry of prepared) {
+            const { minX: polyMinX, maxX: polyMaxX, minY: polyMinY, maxY: polyMaxY } = entry.bounds;
+            const startX = Math.max(0, Math.floor(polyMinX - minX));
+            const endX = Math.min(width - 1, Math.ceil(polyMaxX - minX));
+            const startY = Math.max(0, Math.floor(polyMinY - minY));
+            const endY = Math.min(height - 1, Math.ceil(polyMaxY - minY));
+            if (endX < startX || endY < startY) continue;
+            for (let y = startY; y <= endY; y++) {
+                const sampleY = minY + y + 0.5;
+                if (sampleY < polyMinY - 1e-3 || sampleY > polyMaxY + 1e-3) continue;
+                for (let x = startX; x <= endX; x++) {
+                    const sampleX = minX + x + 0.5;
+                    if (sampleX < polyMinX - 1e-3 || sampleX > polyMaxX + 1e-3) continue;
+                    if (blockGeometry.pointInPolygon({ x: sampleX, y: sampleY }, entry.polygon)) {
+                        mask[y * width + x] = 255;
+                    }
+                }
+            }
+        }
+        return mask;
     };
 
     // Stable node key generator: snap coordinates to a small grid before stringifying.
@@ -2057,6 +2146,18 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                     const spriteW = Math.max(4, Math.ceil(maxX - minX));
                     const spriteH = Math.max(4, Math.ceil(maxY - minY));
                     let cracksDisplay: PIXI.DisplayObject | null = null;
+                    let crashMaskDebugGraphics: PIXI.Graphics | null = null;
+                    const crashMaskActive = !!(renderCfg.crashMaskEnabled);
+                    const wantCrashMaskDebug = !!(renderCfg.debugCrackMask);
+                    const shouldBuildCrashMask = (crashMaskActive || wantCrashMaskDebug) && polys.length > 0;
+                    let polygonMask: Uint8Array | null = null;
+                    if (shouldBuildCrashMask) {
+                        try {
+                            polygonMask = buildPolygonMask(polys, spriteW, spriteH, minX, minY);
+                        } catch (e) {
+                            polygonMask = null;
+                        }
+                    }
 
                     if (useProceduralCracks) {
                         const raster = generateCrackRaster({
@@ -2066,6 +2167,8 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                             minY,
                             renderConfig: renderCfg,
                             isoToWorld,
+                            debugMask: polygonMask ? { data: polygonMask, width: spriteW, height: spriteH } : undefined,
+                            captureCrashMask: crashMaskActive || wantCrashMaskDebug,
                         });
                         if (raster) {
                             const alphaMultiplier = (typeof roadCrackAlpha === 'number' && isFinite(roadCrackAlpha)) ? roadCrackAlpha : 1;
@@ -2073,6 +2176,17 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                             if (graphics) {
                                 cracksDisplay = graphics;
                                 proceduralCrackGraphicsRef.current = graphics;
+                                if (wantCrashMaskDebug && raster.crashMask) {
+                                    crashMaskDebugGraphics = maskToGraphics(
+                                        raster.crashMask.data,
+                                        raster.crashMask.width,
+                                        raster.crashMask.height,
+                                        spriteW,
+                                        spriteH,
+                                        0x00FFFF,
+                                        0.25
+                                    );
+                                }
                             }
                         }
                     }
@@ -2130,6 +2244,9 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                         cracksDisplay.x = 0;
                         cracksDisplay.y = 0;
                         container.addChild(cracksDisplay);
+                        if (crashMaskDebugGraphics) {
+                            container.addChild(crashMaskDebugGraphics);
+                        }
                         container.addChild(maskG);
                         container.mask = maskG;
                         roadCrackOverlay.current?.addChild(container);

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -285,6 +285,8 @@ export const config = {
     intersectionPatchAlwaysVisibleWithOutlines: true,
     // Mostrar contornos dos quarteirões
     showBlockOutlines: true,
+    // Toggle procedural crash mask (intersection of FBM buckets & road polygons)
+    crashMaskEnabled: false,
     // Crack mask debug/padding controls (UI-adjustable)
     debugCrackMask: false,
     // Show FBM delimitations (separate toggle for fBm regions / buckets)

--- a/src/tools/crackGenerator.ts
+++ b/src/tools/crackGenerator.ts
@@ -173,6 +173,14 @@ export interface CrackRaster {
         minY: number;
         quality: number;
     };
+    crashMask?: {
+        data: Uint8Array;
+        width: number;
+        height: number;
+        minX: number;
+        minY: number;
+        quality: number;
+    };
 }
 
 export interface CrackRasterOptions {
@@ -182,10 +190,23 @@ export interface CrackRasterOptions {
     minY: number;
     renderConfig: any;
     isoToWorld: (point: { x: number; y: number }) => { x: number; y: number };
+    debugMask?: { data: Uint8Array; width: number; height: number };
+    captureCrashMask?: boolean;
 }
 
 export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | null {
-    const { width, height, minX, minY, renderConfig, isoToWorld } = options;
+    const {
+        width: widthRaw,
+        height: heightRaw,
+        minX,
+        minY,
+        renderConfig,
+        isoToWorld,
+        debugMask,
+        captureCrashMask,
+    } = options;
+    const width = Math.max(1, Math.round(widthRaw));
+    const height = Math.max(1, Math.round(heightRaw));
     const crackCfg = renderConfig?.crackProceduralParams || {};
     const fallbackQuality = (typeof crackCfg.quality === 'number' && isFinite(crackCfg.quality))
         ? crackCfg.quality
@@ -301,6 +322,18 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     let debug_regionCellH = 0;
     let debug_buckets = 0;
     const attachDebugRegionRequested = !!(renderConfig && renderConfig.showFbmDelimitations);
+    let debugMaskData: Uint8Array | null = null;
+    if (debugMask && debugMask.data) {
+        if (debugMask.width === width && debugMask.height === height) {
+            debugMaskData = debugMask.data;
+        } else if (typeof console !== 'undefined' && console.warn) {
+            console.warn('[crackGenerator] Ignoring debugMask due to dimension mismatch', {
+                expected: { width, height }, provided: { width: debugMask.width, height: debugMask.height }
+            });
+        }
+    }
+    const captureCrashMaskActual = !!(captureCrashMask && debugMaskData);
+    const crashMaskData = captureCrashMaskActual ? new Uint8Array(width * height) : null;
 
     if (renderConfig?.crackUseNoise) {
         const noiseCfg = renderConfig.crackNoiseParams || { baseScale: 1 / 480, octaves: 4, lacunarity: 2, gain: 0.5, buckets: 3, crackBandWidth: 0.012, maxActiveBuckets: 2, activeBucketStrategy: 'smallest' };
@@ -384,7 +417,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             }
         }
 
-    const bucketNoise: Noise[] = new Array(buckets);
+        const bucketNoise: Noise[] = new Array(buckets);
         const bucketCenters: number[] = new Array(buckets);
         const fineScales: number[] = new Array(buckets);
         for (let b = 0; b < buckets; b++) {
@@ -393,10 +426,10 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             fineScales[b] = baseScale * (1.5 + b * 0.6);
         }
 
-    const invQuality = 1 / quality;
-    debug_regionCellW = debug_regionW > 0 ? width / debug_regionW : width;
-    debug_regionCellH = debug_regionH > 0 ? height / debug_regionH : height;
-    debug_buckets = buckets;
+        const invQuality = 1 / quality;
+        debug_regionCellW = debug_regionW > 0 ? width / debug_regionW : width;
+        debug_regionCellH = debug_regionH > 0 ? height / debug_regionH : height;
+        debug_buckets = buckets;
         // Pre-generate an FBM mask at the original render resolution (width x height)
         // and sample it per-canvas pixel. This avoids subtle coordinate mismatches
         // between canvas-res sampling and the coarse region map used below.
@@ -431,16 +464,21 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 if (alpha === 0) continue;
                 const screenX = (x + 0.5) * invQuality;
                 const screenY = (y + 0.5) * invQuality;
+                const baseX = Math.max(0, Math.min(width - 1, Math.floor(screenX)));
+                const baseY = Math.max(0, Math.min(height - 1, Math.floor(screenY)));
+                const baseIndex = baseY * width + baseX;
                 // If we have a full-resolution FBM mask, sample it in screen coords
                 // (mask was generated at original `width`/`height`). If mask says
                 // 'blocked', clear alpha and skip per-bucket checks.
                 if (fbmMaskFull) {
-                    const mx = Math.max(0, Math.min(width - 1, Math.floor(screenX)));
-                    const my = Math.max(0, Math.min(height - 1, Math.floor(screenY)));
-                    if (fbmMaskFull[my * width + mx] === 0) {
+                    if (fbmMaskFull[baseIndex] === 0) {
                         data[idx + 3] = 0;
                         continue;
                     }
+                }
+                if (debugMaskData && debugMaskData[baseIndex] === 0) {
+                    data[idx + 3] = 0;
+                    continue;
                 }
                 const rx = Math.max(0, Math.min(debug_regionW - 1, Math.floor(screenX / (debug_regionCellW || 1))));
                 const ry = Math.max(0, Math.min(debug_regionH - 1, Math.floor(screenY / (debug_regionCellH || 1))));
@@ -484,6 +522,9 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                     data[idx] = color[0];
                     data[idx + 1] = color[1];
                     data[idx + 2] = color[2];
+                    if (crashMaskData) {
+                        crashMaskData[baseIndex] = 255;
+                    }
                 }
             }
         }
@@ -500,11 +541,22 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             data.set(_voronoiCopy);
         }
     } else {
-        for (let i = 0; i < data.length; i += 4) {
-            if (data[i + 3] > 0) {
-                data[i] = 24;
-                data[i + 1] = 24;
-                data[i + 2] = 24;
+        const invQuality = 1 / quality;
+        for (let y = 0; y < canvasH; y++) {
+            for (let x = 0; x < canvasW; x++) {
+                const idx = (y * canvasW + x) * 4;
+                if (data[idx + 3] === 0) continue;
+                data[idx] = 24;
+                data[idx + 1] = 24;
+                data[idx + 2] = 24;
+                if (!crashMaskData) continue;
+                const screenX = (x + 0.5) * invQuality;
+                const screenY = (y + 0.5) * invQuality;
+                const baseX = Math.max(0, Math.min(width - 1, Math.floor(screenX)));
+                const baseY = Math.max(0, Math.min(height - 1, Math.floor(screenY)));
+                const baseIndex = baseY * width + baseX;
+                if (debugMaskData && debugMaskData[baseIndex] === 0) continue;
+                crashMaskData[baseY * width + baseX] = 255;
             }
         }
     }
@@ -518,6 +570,16 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             buckets: debug_buckets,
             cellW: debug_regionCellW,
             cellH: debug_regionCellH,
+            minX,
+            minY,
+            quality,
+        };
+    }
+    if (crashMaskData) {
+        out.crashMask = {
+            data: crashMaskData,
+            width,
+            height,
             minX,
             minY,
             quality,


### PR DESCRIPTION
## Summary
- restrict crash-mask writes to pixels that survive all FBM and polygon filtering so it reflects actual crack paths
- update the non-noise path to map canvas pixels back to crash-mask space while honouring the supplied debug mask

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc52042c48832aa62b3c482de178a5