### PR TITLE
Tighten crack density and guarantee crash mask coverage

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -444,7 +444,9 @@ const App: React.FC = () => {
             <GameCanvas interiorTexture={interiorTexture} interiorTextureScale={texScale} interiorTextureAlpha={texAlpha} interiorTextureTint={parseInt(texTint.slice(1),16)} crossfadeEnabled={crossfadeEnabled} crossfadeMs={crossfadeMs}
                 roadCrackTexture={roadCrackTexture} roadCrackScale={crackScale} roadCrackAlpha={crackAlpha}
                 edgeTexture={edgeTexture} edgeScale={edgeScale} edgeAlpha={edgeAlpha}
-                roadLaneTexture={laneTexture} roadLaneScale={laneScale} roadLaneAlpha={laneAlpha} />
+                roadLaneTexture={laneTexture} roadLaneScale={laneScale} roadLaneAlpha={laneAlpha}
+                crashMaskEnabled={crashMaskEnabled}
+            />
             <div id="control-bar" className={controlsCollapsed ? 'collapsed' : ''}>
                 <button id="control-bar-toggle" onClick={() => setControlsCollapsed(c => !c)} style={{ marginRight: 8 }}>
                     {controlsCollapsed ? 'Expandir' : 'Colapsar'}

--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -40,9 +40,10 @@ interface GameCanvasPropsInternal extends GameCanvasProps {
     roadLaneTexture?: PIXI.Texture | null;
     roadLaneScale?: number;
     roadLaneAlpha?: number;
+    crashMaskEnabled?: boolean;
 }
 
-const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interiorTextureScale, interiorTextureAlpha, interiorTextureTint, crossfadeEnabled, crossfadeMs, roadCrackTexture, roadCrackScale, roadCrackAlpha, edgeTexture, edgeScale, edgeAlpha, roadLaneTexture, roadLaneScale, roadLaneAlpha }) => {
+const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interiorTextureScale, interiorTextureAlpha, interiorTextureTint, crossfadeEnabled, crossfadeMs, roadCrackTexture, roadCrackScale, roadCrackAlpha, edgeTexture, edgeScale, edgeAlpha, roadLaneTexture, roadLaneScale, roadLaneAlpha, crashMaskEnabled }) => {
     const canvasContainerRef = useRef<HTMLDivElement>(null);
     const pixiRenderer = useRef<PIXI.IRenderer<PIXI.ICanvas> | null>(null);
     const stage = useRef<PIXI.Container | null>(null);
@@ -91,6 +92,9 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
     useEffect(() => {
         try { onMapChange(false); } catch (e) {}
     }, [roadCrackTexture, edgeTexture, roadCrackScale, roadCrackAlpha]);
+    useEffect(() => {
+        try { onMapChange(false); } catch (e) {}
+    }, [crashMaskEnabled]);
     useEffect(() => {
         try { roadLaneScaleRef.current = roadLaneScale; } catch (e) {}
     }, [roadLaneScale]);
@@ -195,6 +199,91 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
         }
 
         return graphics;
+    };
+
+    const maskToGraphics = (
+        mask: Uint8Array | null,
+        maskWidth: number,
+        maskHeight: number,
+        spriteW: number,
+        spriteH: number,
+        color: number,
+        alpha: number
+    ): PIXI.Graphics | null => {
+        if (!mask || maskWidth <= 0 || maskHeight <= 0) return null;
+        const finalAlpha = Math.max(0, Math.min(1, alpha));
+        if (finalAlpha <= 0) return null;
+        const stepX = spriteW / maskWidth;
+        const stepY = spriteH / maskHeight;
+        const g = new PIXI.Graphics();
+        let drew = false;
+        for (let y = 0; y < maskHeight; y++) {
+            let runStart = -1;
+            for (let x = 0; x <= maskWidth; x++) {
+                const val = x < maskWidth ? mask[y * maskWidth + x] : 0;
+                if (val > 0) {
+                    if (runStart === -1) runStart = x;
+                } else if (runStart !== -1) {
+                    const runLen = x - runStart;
+                    if (runLen > 0) {
+                        g.beginFill(color, finalAlpha);
+                        g.drawRect(runStart * stepX, y * stepY, runLen * stepX, stepY);
+                        g.endFill();
+                        drew = true;
+                    }
+                    runStart = -1;
+                }
+            }
+        }
+        if (!drew) {
+            try { g.destroy(); } catch (e) {}
+            return null;
+        }
+        return g;
+    };
+
+    const buildPolygonMask = (
+        polygons: { x: number; y: number }[][],
+        width: number,
+        height: number,
+        minX: number,
+        minY: number
+    ): Uint8Array | null => {
+        if (!polygons.length || width <= 0 || height <= 0) return null;
+        const mask = new Uint8Array(width * height);
+        const prepared = polygons.map(poly => {
+            let pMinX = Infinity, pMaxX = -Infinity, pMinY = Infinity, pMaxY = -Infinity;
+            for (const v of poly) {
+                if (v.x < pMinX) pMinX = v.x;
+                if (v.x > pMaxX) pMaxX = v.x;
+                if (v.y < pMinY) pMinY = v.y;
+                if (v.y > pMaxY) pMaxY = v.y;
+            }
+            return {
+                bounds: { minX: pMinX, maxX: pMaxX, minY: pMinY, maxY: pMaxY },
+                polygon: { vertices: poly } as blockGeometry.Polygon,
+            };
+        });
+        for (const entry of prepared) {
+            const { minX: polyMinX, maxX: polyMaxX, minY: polyMinY, maxY: polyMaxY } = entry.bounds;
+            const startX = Math.max(0, Math.floor(polyMinX - minX));
+            const endX = Math.min(width - 1, Math.ceil(polyMaxX - minX));
+            const startY = Math.max(0, Math.floor(polyMinY - minY));
+            const endY = Math.min(height - 1, Math.ceil(polyMaxY - minY));
+            if (endX < startX || endY < startY) continue;
+            for (let y = startY; y <= endY; y++) {
+                const sampleY = minY + y + 0.5;
+                if (sampleY < polyMinY - 1e-3 || sampleY > polyMaxY + 1e-3) continue;
+                for (let x = startX; x <= endX; x++) {
+                    const sampleX = minX + x + 0.5;
+                    if (sampleX < polyMinX - 1e-3 || sampleX > polyMaxX + 1e-3) continue;
+                    if (blockGeometry.pointInPolygon({ x: sampleX, y: sampleY }, entry.polygon)) {
+                        mask[y * width + x] = 255;
+                    }
+                }
+            }
+        }
+        return mask;
     };
 
     // Stable node key generator: snap coordinates to a small grid before stringifying.
@@ -2057,6 +2146,18 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                     const spriteW = Math.max(4, Math.ceil(maxX - minX));
                     const spriteH = Math.max(4, Math.ceil(maxY - minY));
                     let cracksDisplay: PIXI.DisplayObject | null = null;
+                    let crashMaskDebugGraphics: PIXI.Graphics | null = null;
+                    const crashMaskActive = !!(renderCfg.crashMaskEnabled);
+                    const wantCrashMaskDebug = !!(renderCfg.debugCrackMask);
+                    const shouldBuildCrashMask = (crashMaskActive || wantCrashMaskDebug) && polys.length > 0;
+                    let polygonMask: Uint8Array | null = null;
+                    if (shouldBuildCrashMask) {
+                        try {
+                            polygonMask = buildPolygonMask(polys, spriteW, spriteH, minX, minY);
+                        } catch (e) {
+                            polygonMask = null;
+                        }
+                    }
 
                     if (useProceduralCracks) {
                         const raster = generateCrackRaster({
@@ -2066,6 +2167,8 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                             minY,
                             renderConfig: renderCfg,
                             isoToWorld,
+                            debugMask: polygonMask ? { data: polygonMask, width: spriteW, height: spriteH } : undefined,
+                            captureCrashMask: crashMaskActive || wantCrashMaskDebug,
                         });
                         if (raster) {
                             const alphaMultiplier = (typeof roadCrackAlpha === 'number' && isFinite(roadCrackAlpha)) ? roadCrackAlpha : 1;
@@ -2073,6 +2176,17 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                             if (graphics) {
                                 cracksDisplay = graphics;
                                 proceduralCrackGraphicsRef.current = graphics;
+                                if (wantCrashMaskDebug && raster.crashMask) {
+                                    crashMaskDebugGraphics = maskToGraphics(
+                                        raster.crashMask.data,
+                                        raster.crashMask.width,
+                                        raster.crashMask.height,
+                                        spriteW,
+                                        spriteH,
+                                        0x00FFFF,
+                                        0.25
+                                    );
+                                }
                             }
                         }
                     }
@@ -2130,6 +2244,9 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                         cracksDisplay.x = 0;
                         cracksDisplay.y = 0;
                         container.addChild(cracksDisplay);
+                        if (crashMaskDebugGraphics) {
+                            container.addChild(crashMaskDebugGraphics);
+                        }
                         container.addChild(maskG);
                         container.mask = maskG;
                         roadCrackOverlay.current?.addChild(container);

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -285,6 +285,8 @@ export const config = {
     intersectionPatchAlwaysVisibleWithOutlines: true,
     // Mostrar contornos dos quarteirões
     showBlockOutlines: true,
+    // Toggle procedural crash mask (intersection of FBM buckets & road polygons)
+    crashMaskEnabled: false,
     // Crack mask debug/padding controls (UI-adjustable)
     debugCrackMask: false,
     // Show FBM delimitations (separate toggle for fBm regions / buckets)
@@ -298,7 +300,7 @@ export const config = {
     // Use procedural cracks baked via Voronoi preview logic by default
     crackUseProcedural: true,
     crackProceduralParams: {
-        divisions: 400,
+        divisions: 600,
         thickness: 6,
         dilateRadius: 2,
         quality: 2,

--- a/src/tools/crackGenerator.ts
+++ b/src/tools/crackGenerator.ts
@@ -1,5 +1,4 @@
 import { Noise } from 'noisejs';
-import { generateFbmMask } from './fbmMask';
 
 export interface CrackGeneratorOptions {
     divisions: number;
@@ -18,19 +17,16 @@ function makeRng(seed: number) {
     };
 }
 
-export const fbmNoise = (noise: Noise, x: number, y: number, octaves = 4, lacunarity = 2, gain = 0.5) => {
-    let freq = 1;
-    let amp = 1;
-    let sum = 0;
-    let norm = 0;
-    for (let i = 0; i < octaves; i++) {
-        sum += noise.perlin2(x * freq, y * freq) * amp;
-        norm += amp;
-        freq *= lacunarity;
-        amp *= gain;
-    }
-    const normalized = norm ? sum / norm : 0;
-    return normalized * 0.5 + 0.5;
+export const fbmNoise = (
+    noise: Noise,
+    x: number,
+    y: number,
+    _octaves = 1,
+    _lacunarity = 2,
+    _gain = 0.5,
+) => {
+    const value = noise.perlin2(x, y);
+    return value * 0.5 + 0.5;
 };
 
 export function generateVoronoiCrackImage(width: number, height: number, options: CrackGeneratorOptions): Uint8ClampedArray {
@@ -38,7 +34,10 @@ export function generateVoronoiCrackImage(width: number, height: number, options
     const sh = Math.max(1, Math.round(height));
     const scale = options.scale ?? 1;
     const color: [number, number, number] = options.color ?? [58, 58, 58];
-    const divisions = Math.max(8, Math.min(5000, Math.round(options.divisions)));
+    const baseDivisions = Math.max(8, Math.min(5000, Math.round(options.divisions)));
+    const referenceArea = 512 * 512;
+    const areaScale = Math.max(0.25, Math.min(8, (sw * sh) / referenceArea));
+    const divisions = Math.max(8, Math.min(5000, Math.round(baseDivisions * areaScale)));
     const rng = makeRng(Math.floor(options.seed) || 1);
     const pts = new Float32Array(divisions * 2);
     for (let i = 0; i < divisions; i++) {
@@ -161,7 +160,7 @@ export interface CrackRaster {
     height: number;
     quality: number;
     color: [number, number, number];
-    // Optional debug info for FBM region visualization
+    // Optional debug info for noise bucket region visualization (legacy FBM naming)
     debugRegion?: {
         map: Uint8Array;
         w: number;
@@ -169,6 +168,14 @@ export interface CrackRaster {
         buckets: number;
         cellW: number;
         cellH: number;
+        minX: number;
+        minY: number;
+        quality: number;
+    };
+    crashMask?: {
+        data: Uint8Array;
+        width: number;
+        height: number;
         minX: number;
         minY: number;
         quality: number;
@@ -182,10 +189,23 @@ export interface CrackRasterOptions {
     minY: number;
     renderConfig: any;
     isoToWorld: (point: { x: number; y: number }) => { x: number; y: number };
+    debugMask?: { data: Uint8Array; width: number; height: number };
+    captureCrashMask?: boolean;
 }
 
 export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | null {
-    const { width, height, minX, minY, renderConfig, isoToWorld } = options;
+    const {
+        width: widthRaw,
+        height: heightRaw,
+        minX,
+        minY,
+        renderConfig,
+        isoToWorld,
+        debugMask,
+        captureCrashMask,
+    } = options;
+    const width = Math.max(1, Math.round(widthRaw));
+    const height = Math.max(1, Math.round(heightRaw));
     const crackCfg = renderConfig?.crackProceduralParams || {};
     const fallbackQuality = (typeof crackCfg.quality === 'number' && isFinite(crackCfg.quality))
         ? crackCfg.quality
@@ -220,9 +240,9 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
         if (typeof console !== 'undefined' && console.warn) {
             console.warn('[crackGenerator] Procedural crack raster skipped – area too large after clamping', { canvasW, canvasH, quality });
         }
-        // If the caller explicitly requested FBM debug delimitations, return a
+        // If the caller explicitly requested legacy FBM debug delimitations, return a
         // tiny placeholder raster that includes a coarse `debugRegion` so the
-        // UI can still visualize FBM buckets even when the full raster is
+        // UI can still visualize noise buckets even when the full raster is
         // skipped due to clamping limits.
     if (renderConfig?.showFbmDelimitations && renderConfig?.crackUseNoise) {
             try {
@@ -289,9 +309,10 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     });
 
     // Keep a copy of the raw Voronoi result as a fallback in case later
-    // FBM/noise filtering removes all pixels (so the user isn't left with
+    // noise filtering removes all pixels (so the user isn't left with
     // an empty transparent result because of restrictive params).
     const _voronoiCopy = new Uint8ClampedArray(data);
+    const invQuality = 1 / quality;
 
     // Debug region variables (declared in outer scope so we can attach info after noise processing)
     let debug_regionMap: Uint8Array | null = null;
@@ -301,23 +322,35 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     let debug_regionCellH = 0;
     let debug_buckets = 0;
     const attachDebugRegionRequested = !!(renderConfig && renderConfig.showFbmDelimitations);
+    let debugMaskData: Uint8Array | null = null;
+    if (debugMask && debugMask.data) {
+        if (debugMask.width === width && debugMask.height === height) {
+            debugMaskData = debugMask.data;
+        } else if (typeof console !== 'undefined' && console.warn) {
+            console.warn('[crackGenerator] Ignoring debugMask due to dimension mismatch', {
+                expected: { width, height }, provided: { width: debugMask.width, height: debugMask.height }
+            });
+        }
+    }
+    const captureCrashMaskActual = !!(captureCrashMask && debugMaskData);
+    const crashMaskData = captureCrashMaskActual ? new Uint8Array(width * height) : null;
+    let crashMaskCount = 0;
+    let activeBuckets: Set<number> | null = null;
+    let sampleBucketId: ((screenX: number, screenY: number) => number) | null = null;
 
     if (renderConfig?.crackUseNoise) {
-        const noiseCfg = renderConfig.crackNoiseParams || { baseScale: 1 / 480, octaves: 4, lacunarity: 2, gain: 0.5, buckets: 3, crackBandWidth: 0.012, maxActiveBuckets: 2, activeBucketStrategy: 'smallest' };
+        const noiseCfg = renderConfig.crackNoiseParams || { baseScale: 1 / 480, buckets: 3, maxActiveBuckets: 2, activeBucketStrategy: 'smallest' };
         const baseScale = noiseCfg.baseScale || 1 / 480;
-        const octaves = noiseCfg.octaves || 4;
-        const lacunarity = noiseCfg.lacunarity || 2;
-        const gain = noiseCfg.gain || 0.5;
         const buckets = Math.max(1, Math.min(8, noiseCfg.buckets || 3));
-        const crackBandWidth = Math.max(0.002, Math.min(0.1, noiseCfg.crackBandWidth || 0.012));
         const maxActive = Math.max(1, Math.min(buckets, noiseCfg.maxActiveBuckets || 2));
         const strategy = noiseCfg.activeBucketStrategy || 'smallest';
         const regionSample = Math.max(16, Math.min(128, Math.floor(Math.min(width, height) / 6) || 16));
         debug_regionW = Math.max(1, Math.floor(width / regionSample));
         debug_regionH = Math.max(1, Math.floor(height / regionSample));
-    const regionNoise = new Noise(seed || 1);
-    debug_regionMap = new Uint8Array(debug_regionW * debug_regionH);
-    const counts = new Array<number>(buckets).fill(0);
+        const regionNoise = new Noise(seed || 1);
+        debug_regionMap = new Uint8Array(debug_regionW * debug_regionH);
+        const countsAll = new Array<number>(buckets).fill(0);
+        const countsInMask = new Array<number>(buckets).fill(0);
         for (let ry = 0; ry < debug_regionH; ry++) {
             for (let rx = 0; rx < debug_regionW; rx++) {
                 const sampleX = ((rx + 0.5) / debug_regionW) * width;
@@ -326,45 +359,77 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 // In isometric mode other overlays (NoiseZoning) sample noise using
                 // projected/screen coordinates (they map canvas pixels -> scene using
                 // cameraX/cameraY/zoom). To keep behavior consistent and ensure the
-                // FBM area follows zoom/pan, when renderConfig indicates isometric
+                // Noise area follows zoom/pan, when renderConfig indicates isometric
                 // mode we sample directly in projected coordinates. For non-
                 // isometric mode fall back to the provided isoToWorld mapping.
                 const worldPt = (renderConfig && renderConfig.mode === 'isometric')
                     ? { x: screenPt.x, y: screenPt.y }
                     : isoToWorld(screenPt);
-                const v = fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+                const v = fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale);
                 let id = Math.floor(v * buckets);
                 if (id < 0) id = 0;
                 if (id >= buckets) id = buckets - 1;
                 debug_regionMap![ry * debug_regionW + rx] = id;
-                counts[id]++;
+                countsAll[id]++;
+                if (!debugMaskData) {
+                    countsInMask[id]++;
+                } else {
+                    const baseX = Math.max(0, Math.min(width - 1, Math.floor(sampleX)));
+                    const baseY = Math.max(0, Math.min(height - 1, Math.floor(sampleY)));
+                    const baseIndex = baseY * width + baseX;
+                    if (debugMaskData[baseIndex] !== 0) {
+                        countsInMask[id]++;
+                    }
+                }
             }
         }
 
-        const stats = counts.map((c, i) => ({ i, c }));
-        let picked: { i: number; c: number }[] = [];
-        if (strategy === 'largest') {
-            picked = stats.slice().sort((a, b) => b.c - a.c).slice(0, maxActive);
-        } else if (strategy === 'random') {
-            const rng = (() => {
-                let t = (seed ^ 0x9E3779B9) >>> 0;
-                return () => {
-                    t = (t * 1664525 + 1013904223) >>> 0;
-                    return t / 0x100000000;
-                };
-            })();
-            const arr = stats.slice();
-            for (let i = arr.length - 1; i > 0; i--) {
-                const j = Math.floor(rng() * (i + 1));
-                const tmp = arr[i];
-                arr[i] = arr[j];
-                arr[j] = tmp;
+        const statsAll = countsAll.map((c, i) => ({ i, c }));
+        const statsMask = countsInMask.map((c, i) => ({ i, c }));
+        const positiveMask = statsMask.filter(s => s.c > 0);
+        const positiveAll = statsAll.filter(s => s.c > 0);
+        const selectionPool = debugMaskData
+            ? (positiveMask.length > 0 ? positiveMask : (positiveAll.length > 0 ? positiveAll : statsMask))
+            : (positiveAll.length > 0 ? positiveAll : statsAll);
+        const rng = (() => {
+            let t = (seed ^ 0x9E3779B9) >>> 0;
+            return () => {
+                t = (t * 1664525 + 1013904223) >>> 0;
+                return t / 0x100000000;
+            };
+        })();
+        const pickByStrategy = (pool: { i: number; c: number }[], count: number) => {
+            if (pool.length === 0 || count <= 0) return [] as { i: number; c: number }[];
+            if (strategy === 'largest') {
+                return pool.slice().sort((a, b) => (b.c - a.c) || (a.i - b.i)).slice(0, count);
             }
-            picked = arr.slice(0, maxActive);
-        } else {
-            picked = stats.slice().sort((a, b) => a.c - b.c).slice(0, maxActive);
+            if (strategy === 'random') {
+                const arr = pool.slice();
+                for (let i = arr.length - 1; i > 0; i--) {
+                    const j = Math.floor(rng() * (i + 1));
+                    const tmp = arr[i];
+                    arr[i] = arr[j];
+                    arr[j] = tmp;
+                }
+                return arr.slice(0, count);
+            }
+            return pool.slice().sort((a, b) => (a.c - b.c) || (a.i - b.i)).slice(0, count);
+        };
+
+        let picked = pickByStrategy(selectionPool, maxActive);
+        if (picked.length < maxActive) {
+            const fallbackPoolBase = positiveAll.length > 0 ? positiveAll : statsAll;
+            const fallbackPool = fallbackPoolBase.filter(item => !picked.some(p => p.i === item.i));
+            const extra = pickByStrategy(fallbackPool.length > 0 ? fallbackPool : statsAll.filter(item => !picked.some(p => p.i === item.i)), maxActive - picked.length);
+            picked = picked.concat(extra);
         }
-        let activeBuckets = new Set<number>(picked.map(p => p.i));
+        if (picked.length < maxActive) {
+            for (let b = 0; picked.length < maxActive && b < buckets; b++) {
+                if (picked.some(p => p.i === b)) continue;
+                picked.push({ i: b, c: 0 });
+            }
+        }
+        activeBuckets = new Set<number>(picked.map(p => p.i));
         if (activeBuckets.size === 0) {
             for (let b = 0; b < buckets; b++) activeBuckets.add(b);
         }
@@ -384,46 +449,26 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             }
         }
 
-    const bucketNoise: Noise[] = new Array(buckets);
-        const bucketCenters: number[] = new Array(buckets);
-        const fineScales: number[] = new Array(buckets);
-        for (let b = 0; b < buckets; b++) {
-            bucketNoise[b] = new Noise(seed + b * 97 + 13);
-            bucketCenters[b] = (b + 0.5) / buckets;
-            fineScales[b] = baseScale * (1.5 + b * 0.6);
-        }
+        debug_regionCellW = debug_regionW > 0 ? width / debug_regionW : width;
+        debug_regionCellH = debug_regionH > 0 ? height / debug_regionH : height;
+        debug_buckets = buckets;
+        sampleBucketId = (screenX: number, screenY: number) => {
+            const rx = Math.max(0, Math.min(debug_regionW - 1, Math.floor(screenX / (debug_regionCellW || 1))));
+            const ry = Math.max(0, Math.min(debug_regionH - 1, Math.floor(screenY / (debug_regionCellH || 1))));
+            return debug_regionMap![ry * debug_regionW + rx];
+        };
 
-    const invQuality = 1 / quality;
-    debug_regionCellW = debug_regionW > 0 ? width / debug_regionW : width;
-    debug_regionCellH = debug_regionH > 0 ? height / debug_regionH : height;
-    debug_buckets = buckets;
-        // Pre-generate an FBM mask at the original render resolution (width x height)
-        // and sample it per-canvas pixel. This avoids subtle coordinate mismatches
-        // between canvas-res sampling and the coarse region map used below.
-        let fbmMaskFull: Uint8Array | null = null;
-        try {
-            fbmMaskFull = generateFbmMask({
-                width: width,
-                height: height,
-                minX,
-                minY,
-                seed,
-                baseScale,
-                octaves,
-                lacunarity,
-                gain,
-                buckets,
-                maxActiveBuckets: noiseCfg.maxActiveBuckets,
-                activeBucketStrategy: noiseCfg.activeBucketStrategy,
-                crackBandWidth: noiseCfg.crackBandWidth,
-                mode: renderConfig?.mode === 'isometric' ? 'isometric' : 'normal',
-                isoToWorld,
-            });
-        } catch (e) {
-            // If mask generation fails, fall back to no mask (null)
-            fbmMaskFull = null;
-        }
-
+        const palette = [
+            [220, 38, 38],    // vermelho
+            [34, 197, 94],    // verde
+            [37, 99, 235],    // azul
+            [234, 179, 8],    // amarelo
+            [168, 85, 247],   // roxo
+            [16, 185, 129],   // teal
+            [251, 191, 36],   // laranja
+            [244, 63, 94],    // rosa
+        ];
+        let hasCoverage = false;
         for (let y = 0; y < canvasH; y++) {
             for (let x = 0; x < canvasW; x++) {
                 const idx = (y * canvasW + x) * 4;
@@ -431,80 +476,111 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 if (alpha === 0) continue;
                 const screenX = (x + 0.5) * invQuality;
                 const screenY = (y + 0.5) * invQuality;
-                // If we have a full-resolution FBM mask, sample it in screen coords
-                // (mask was generated at original `width`/`height`). If mask says
-                // 'blocked', clear alpha and skip per-bucket checks.
-                if (fbmMaskFull) {
-                    const mx = Math.max(0, Math.min(width - 1, Math.floor(screenX)));
-                    const my = Math.max(0, Math.min(height - 1, Math.floor(screenY)));
-                    if (fbmMaskFull[my * width + mx] === 0) {
+                const baseX = Math.max(0, Math.min(width - 1, Math.floor(screenX)));
+                const baseY = Math.max(0, Math.min(height - 1, Math.floor(screenY)));
+                const baseIndex = baseY * width + baseX;
+                if (debugMaskData && debugMaskData[baseIndex] === 0) {
+                    data[idx + 3] = 0;
+                    continue;
+                }
+                const bucketId = sampleBucketId!(screenX, screenY);
+                if (!activeBuckets!.has(bucketId)) {
+                    data[idx + 3] = 0;
+                    continue;
+                }
+                const color = palette[bucketId % palette.length];
+                data[idx] = color[0];
+                data[idx + 1] = color[1];
+                data[idx + 2] = color[2];
+                hasCoverage = true;
+            }
+        }
+        if (crashMaskData) {
+            for (let y = 0; y < height; y++) {
+                for (let x = 0; x < width; x++) {
+                    const baseIndex = y * width + x;
+                    if (debugMaskData && debugMaskData[baseIndex] === 0) continue;
+                    const bucketId = sampleBucketId!(x + 0.5, y + 0.5);
+                    if (activeBuckets!.has(bucketId) && crashMaskData[baseIndex] === 0) {
+                        crashMaskData[baseIndex] = 255;
+                        crashMaskCount++;
+                    }
+                }
+            }
+        }
+        if (crashMaskData && crashMaskCount === 0 && debugMaskData) {
+            for (let i = 0; i < debugMaskData.length; i++) {
+                if (debugMaskData[i] !== 0) {
+                    crashMaskData[i] = 255;
+                    crashMaskCount++;
+                }
+            }
+        }
+        if (!hasCoverage) {
+            // Restore the original Voronoi image and warn so user can adjust
+            if (typeof console !== 'undefined' && console.warn) {
+                console.warn('[crackGenerator] Noise bucket filtering removed all pixels; restoring fallback Voronoi image. Try adjusting crackNoiseParams (buckets/maxActiveBuckets) or change seed.');
+            }
+            let fallbackHits = 0;
+            for (let y = 0; y < canvasH; y++) {
+                for (let x = 0; x < canvasW; x++) {
+                    const idx = (y * canvasW + x) * 4;
+                    const srcAlpha = _voronoiCopy[idx + 3];
+                    if (srcAlpha === 0) {
+                        data[idx] = 0;
+                        data[idx + 1] = 0;
+                        data[idx + 2] = 0;
                         data[idx + 3] = 0;
                         continue;
                     }
-                }
-                const rx = Math.max(0, Math.min(debug_regionW - 1, Math.floor(screenX / (debug_regionCellW || 1))));
-                const ry = Math.max(0, Math.min(debug_regionH - 1, Math.floor(screenY / (debug_regionCellH || 1))));
-                const bucketId = debug_regionMap![ry * debug_regionW + rx];
-                if (!activeBuckets.has(bucketId)) {
-                    data[idx + 3] = 0;
-                    continue;
-                }
-                const noiseInst = bucketNoise[bucketId];
-                const samplePt = { x: screenX + minX, y: screenY + minY };
-                const worldPt = (renderConfig && renderConfig.mode === 'isometric')
-                    ? { x: samplePt.x, y: samplePt.y }
-                    : isoToWorld(samplePt);
-                const baseVal = fbmNoise(noiseInst, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
-                const dist = Math.abs(baseVal - bucketCenters[bucketId]);
-                if (dist > crackBandWidth) {
-                    data[idx + 3] = 0;
-                    continue;
-                }
-                const edge = Math.max(0, (crackBandWidth - dist) / crackBandWidth);
-                const edgeSoft = Math.pow(edge, 1.2);
-                const fine = fbmNoise(noiseInst, worldPt.x * fineScales[bucketId] * 3.0, worldPt.y * fineScales[bucketId] * 3.0, 2, 2, 0.6);
-                const modulation = Math.max(0, Math.min(1, edgeSoft * (0.35 + 0.65 * fine)));
-                const newAlpha = Math.round(alpha * modulation);
-                if (newAlpha < 12) {
-                    data[idx + 3] = 0;
-                } else {
-                    data[idx + 3] = newAlpha;
-                    // Paleta simples para buckets: cores bem distintas
-                    const palette = [
-                        [220, 38, 38],    // vermelho
-                        [34, 197, 94],    // verde
-                        [37, 99, 235],    // azul
-                        [234, 179, 8],    // amarelo
-                        [168, 85, 247],   // roxo
-                        [16, 185, 129],   // teal
-                        [251, 191, 36],   // laranja
-                        [244, 63, 94],    // rosa
-                    ];
-                    const color = palette[bucketId % palette.length];
-                    data[idx] = color[0];
-                    data[idx + 1] = color[1];
-                    data[idx + 2] = color[2];
+                    const screenX = (x + 0.5) * invQuality;
+                    const screenY = (y + 0.5) * invQuality;
+                    const baseX = Math.max(0, Math.min(width - 1, Math.floor(screenX)));
+                    const baseY = Math.max(0, Math.min(height - 1, Math.floor(screenY)));
+                    const baseIndex = baseY * width + baseX;
+                    if (debugMaskData && debugMaskData[baseIndex] === 0) {
+                        data[idx] = 0;
+                        data[idx + 1] = 0;
+                        data[idx + 2] = 0;
+                        data[idx + 3] = 0;
+                        continue;
+                    }
+                    data[idx] = _voronoiCopy[idx];
+                    data[idx + 1] = _voronoiCopy[idx + 1];
+                    data[idx + 2] = _voronoiCopy[idx + 2];
+                    data[idx + 3] = srcAlpha;
+                    fallbackHits++;
                 }
             }
-        }
-        // After applying FBM filtering, ensure we didn't zero-out entire image
-        let any = false;
-        for (let i = 0; i < data.length; i += 4) {
-            if (data[i + 3] > 0) { any = true; break; }
-        }
-        if (!any) {
-            // Restore the original Voronoi image and warn so user can adjust
-            if (typeof console !== 'undefined' && console.warn) {
-                console.warn('[crackGenerator] FBM filters removed all pixels; restoring fallback Voronoi image. Try loosening crackNoiseParams (crackBandWidth, maxActiveBuckets, buckets) or change seed.');
+            hasCoverage = fallbackHits > 0;
+            if (crashMaskData && debugMaskData) {
+                crashMaskData.fill(0);
+                crashMaskCount = 0;
+                for (let i = 0; i < debugMaskData.length; i++) {
+                    if (debugMaskData[i] !== 0) {
+                        crashMaskData[i] = 255;
+                        crashMaskCount++;
+                    }
+                }
             }
-            data.set(_voronoiCopy);
         }
     } else {
-        for (let i = 0; i < data.length; i += 4) {
-            if (data[i + 3] > 0) {
-                data[i] = 24;
-                data[i + 1] = 24;
-                data[i + 2] = 24;
+        for (let y = 0; y < canvasH; y++) {
+            for (let x = 0; x < canvasW; x++) {
+                const idx = (y * canvasW + x) * 4;
+                if (data[idx + 3] === 0) continue;
+                data[idx] = 24;
+                data[idx + 1] = 24;
+                data[idx + 2] = 24;
+            }
+        }
+        if (crashMaskData) {
+            for (let y = 0; y < height; y++) {
+                for (let x = 0; x < width; x++) {
+                    const baseIndex = y * width + x;
+                    if (debugMaskData && debugMaskData[baseIndex] === 0) continue;
+                    crashMaskData[baseIndex] = 255;
+                }
             }
         }
     }
@@ -518,6 +594,16 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             buckets: debug_buckets,
             cellW: debug_regionCellW,
             cellH: debug_regionCellH,
+            minX,
+            minY,
+            quality,
+        };
+    }
+    if (crashMaskData) {
+        out.crashMask = {
+            data: crashMaskData,
+            width,
+            height,
             minX,
             minY,
             quality,


### PR DESCRIPTION
## Summary
- replace the FBM helper with a single-octave Perlin sampler while keeping the legacy API shape
- drive crack rendering and crash-mask eligibility from the active bucket set without generating a separate FBM mask
- build the crash mask at base resolution as the intersection of the active buckets and the provided debug mask
- scale Voronoi point density with the rendered area and favor debug-mask coverage when selecting active buckets so cracks always appear inside streets while falling back to the raw Voronoi field if masking removes everything

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc52042c48832aa62b3c482de178a5