### PR TITLE
Replace FBM with warped simplex noise

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -850,11 +850,14 @@ const App: React.FC = () => {
                     <input type="checkbox" checked={Boolean((config as any).render?.debugCrackMask)} onChange={(e) => { (config as any).render = { ...(config as any).render, debugCrackMask: e.target.checked }; setUiTick(t => t + 1); }} /> Show crack mask debug
                 </label>
                 <label style={{ marginLeft: 8, display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-                    <input type="checkbox" checked={Boolean((config as any).render?.showFbmDelimitations)} onChange={(e) => { (config as any).render = { ...(config as any).render, showFbmDelimitations: e.target.checked }; try { localStorage.setItem('showFbmDelimitations', String(e.target.checked)); } catch (e) {} setUiTick(t => t + 1); }} /> Show FBM delimitations
+                    <input type="checkbox" checked={Boolean((config as any).render?.showNoiseDelimitations)} onChange={(e) => { (config as any).render = { ...(config as any).render, showNoiseDelimitations: e.target.checked }; try {
+                        localStorage.setItem('showNoiseDelimitations', String(e.target.checked));
+                    } catch (e) {}
+                    setUiTick(t => t + 1); }} /> Show noise delimitations
                 </label>
-                {/* Small UI panel showing detected FBM buckets and manual overrides */}
+                {/* Small UI panel showing detected noise buckets and manual overrides */}
                 <div style={{ marginLeft: 8, display: 'inline-flex', alignItems: 'center', gap: 8 }}>
-                    {/* Legend for FBM bucket states */}
+                    {/* Legend for noise bucket states */}
                     <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8, background: 'rgba(0,0,0,0.2)', padding: '6px 8px', borderRadius: 6 }}>
                         <div style={{ display: 'inline-flex', flexDirection: 'column', gap: 4, alignItems: 'flex-start' }}>
                             <div style={{ fontSize: 11, color: '#EEE', fontWeight: 700 }}>Legenda</div>
@@ -879,13 +882,13 @@ const App: React.FC = () => {
                     </div>
                     {(() => {
                         try {
-                            const detected: Record<number, number> | undefined = (config as any).render?.detectedFbmBuckets;
+                            const detected: Record<number, number> | undefined = (config as any).render?.detectedNoiseBuckets;
                             const forced: number[] | undefined = (config as any).render?.forceActiveBucketIds;
                             if (!detected) return null;
                             const ids = Object.keys(detected).map(k => parseInt(k, 10)).filter(n => !isNaN(n)).sort((a,b)=>a-b);
                             return (
                                 <div style={{ display: 'inline-flex', gap: 6, alignItems: 'center', background: 'rgba(0,0,0,0.45)', padding: '6px 8px', borderRadius: 6 }}>
-                                    <div style={{ fontSize: 12, fontWeight: 700, color: '#EEE', marginRight: 6 }}>FBM Buckets</div>
+                                    <div style={{ fontSize: 12, fontWeight: 700, color: '#EEE', marginRight: 6 }}>Noise buckets</div>
                                     {ids.map(id => {
                                         const count = detected[id] || 0;
                                         const active = Array.isArray(forced) ? forced.indexOf(id) >= 0 : false;

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -285,12 +285,12 @@ export const config = {
     intersectionPatchAlwaysVisibleWithOutlines: true,
     // Mostrar contornos dos quarteirões
     showBlockOutlines: true,
-    // Toggle procedural crash mask (intersection of FBM buckets & road polygons)
+    // Toggle procedural crash mask (intersection of noise buckets & road polygons)
     crashMaskEnabled: false,
     // Crack mask debug/padding controls (UI-adjustable)
     debugCrackMask: false,
-    // Show FBM delimitations (separate toggle for fBm regions / buckets)
-    showFbmDelimitations: false,
+    // Show noise delimitations (separate toggle for warped-noise regions / buckets)
+    showNoiseDelimitations: false,
     // Default padding (px) used for crack mask bounding boxes
     crackMaskPaddingDefault: 4,
     // Extra padding (px) applied when heuristic triggers — fallback default 8
@@ -305,11 +305,11 @@ export const config = {
         dilateRadius: 2,
         quality: 2,
     },
-    // Use Perlin/Fbm noise to distribute cracks instead of masking full roads
+    // Use warped simplex noise to distribute cracks instead of masking full roads
     crackUseNoise: true,
-    // Parâmetros para geração procedural de rachaduras via fBm/Perlin.
+    // Parâmetros para geração procedural de rachaduras via ruído simplex com domain warp.
     // - baseScale: frequência base do ruído (1/meters). Valores maiores => manchas maiores.
-    // - octaves/lacunarity/gain: parâmetros de fBm.
+    // - octaves/lacunarity/gain: parâmetros que controlam camadas de warping.
     // - buckets: número de regiões quantizadas no mapa de ruído.
     // - crackBandWidth: largura da faixa em torno do centro do bucket que gera rachaduras (0.002..0.1)
     // - maxActiveBuckets: quantos buckets são efetivamente usados para desenhar rachaduras

--- a/src/game_modules/zoning.ts
+++ b/src/game_modules/zoning.ts
@@ -3,6 +3,7 @@ import type { Point } from '../generic_modules/math';
 import type { ZoneName } from './mapgen';
 import { heatmap } from './mapgen';
 import { config } from './config';
+import { warpedSimplexNoise, warpedSimplexNoiseSigned } from '../tools/noiseSampler';
 
 export type ZoningParams = {
   baseScale: number;
@@ -11,17 +12,6 @@ export type ZoningParams = {
   gain: number;
   thresholds: { r1: number; r2: number; r3: number; r4: number };
 };
-
-function fbm(noise: Noise, x: number, y: number, octaves = 4, lacunarity = 2, gain = 0.5): number {
-  let freq = 1, amp = 1, sum = 0, norm = 0;
-  for (let i = 0; i < octaves; i++) {
-    sum += noise.perlin2(x * freq, y * freq) * amp;
-    norm += amp;
-    freq *= lacunarity;
-    amp *= gain;
-  }
-  return (sum / (norm || 1)) * 0.5 + 0.5;
-}
 
 const Zoning = new (class {
   private _noise: Noise | null = null;
@@ -97,7 +87,7 @@ const Zoning = new (class {
   private _macroNoise(x: number, y: number): number {
     const mn = config.zoningModel.macroNoise;
     if (!this._noise) return 0;
-    return fbm(this._noise, x * mn.baseScale, y * mn.baseScale, mn.octaves, mn.lacunarity, mn.gain) * 2 - 1; // [-1,1]
+    return warpedSimplexNoiseSigned(this._noise, x * mn.baseScale, y * mn.baseScale, mn.octaves, mn.lacunarity, mn.gain); // [-1,1]
   }
 
   private _scoreProcedural(p: Point): Record<ZoneName, number> {
@@ -153,7 +143,7 @@ const Zoning = new (class {
       else z = 'rural';
   } else if (config.zoningModel.mode === 'perlin') {
       const { baseScale, octaves, lacunarity, gain, thresholds } = this._params;
-      const n = fbm(this._noise, p.x * baseScale, p.y * baseScale, octaves, lacunarity, gain);
+      const n = warpedSimplexNoise(this._noise, p.x * baseScale, p.y * baseScale, octaves, lacunarity, gain);
       if (n < thresholds.r1) z = 'rural';
       else if (n < thresholds.r2) z = 'residential';
       else if (n < thresholds.r3) z = 'commercial';

--- a/src/overlays/NoiseZoning.ts
+++ b/src/overlays/NoiseZoning.ts
@@ -1,6 +1,6 @@
 /*
  * NoiseZoning Overlay
- * Perlin/fBm-only zoning overlay for city generator
+ * Domain-warped simplex noise zoning overlay for city generator
  * API: attach(canvas), toggle(), reseed(), redraw()
  * Independent of roads/buildings
  */
@@ -8,22 +8,7 @@ import { ZoneName } from '../game_modules/mapgen';
 import { config } from '../game_modules/config';
 import Zoning from '../game_modules/zoning';
 import { Noise } from 'noisejs';
-
-// Simple Perlin noise implementation (can be replaced by external lib)
-function fbm(noise: Noise, x: number, y: number, octaves = 4, lacunarity = 2, gain = 0.5): number {
-  let freq = 1;
-  let amp = 1;
-  let sum = 0;
-  let norm = 0;
-  for (let i = 0; i < octaves; i++) {
-    sum += noise.perlin2(x * freq, y * freq) * amp;
-    norm += amp;
-    freq *= lacunarity;
-    amp *= gain;
-  }
-  // Map from [-norm, norm] to [0,1]
-  return (sum / (norm || 1)) * 0.5 + 0.5;
-}
+import { warpedSimplexNoise } from '../tools/noiseSampler';
 
 
 export type NoiseZoningAPI = {
@@ -172,7 +157,7 @@ const NoiseZoning: InternalNoiseZoning = {
         // Mapear pixel -> coordenadas de cena, seguindo pan/zoom
         const Sx = cameraX + (x - cx) / zoom;
         const Sy = cameraY + (y - cy) / zoom;
-        const n = fbm(this._noise, Sx * baseScale, Sy * baseScale, octaves, lacunarity, gain);
+        const n = warpedSimplexNoise(this._noise, Sx * baseScale, Sy * baseScale, octaves, lacunarity, gain);
         let zone: ZoneName = 'residential';
         if (n < thresholds.r1) zone = 'rural';
         else if (n < thresholds.r2) zone = 'residential';

--- a/src/tools/crackGenerator.ts
+++ b/src/tools/crackGenerator.ts
@@ -1,4 +1,5 @@
 import { Noise } from 'noisejs';
+import { warpedSimplexNoise } from './noiseSampler';
 
 export interface CrackGeneratorOptions {
     divisions: number;
@@ -17,17 +18,14 @@ function makeRng(seed: number) {
     };
 }
 
-export const fbmNoise = (
+export const warpedNoise = (
     noise: Noise,
     x: number,
     y: number,
-    _octaves = 1,
-    _lacunarity = 2,
-    _gain = 0.5,
-) => {
-    const value = noise.perlin2(x, y);
-    return value * 0.5 + 0.5;
-};
+    octaves = 3,
+    lacunarity = 2,
+    gain = 0.5,
+) => warpedSimplexNoise(noise, x, y, octaves, lacunarity, gain);
 
 export function generateVoronoiCrackImage(width: number, height: number, options: CrackGeneratorOptions): Uint8ClampedArray {
     const sw = Math.max(1, Math.round(width));
@@ -160,7 +158,7 @@ export interface CrackRaster {
     height: number;
     quality: number;
     color: [number, number, number];
-    // Optional debug info for noise bucket region visualization (legacy FBM naming)
+    // Optional debug info for noise bucket region visualization
     debugRegion?: {
         map: Uint8Array;
         w: number;
@@ -240,11 +238,11 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
         if (typeof console !== 'undefined' && console.warn) {
             console.warn('[crackGenerator] Procedural crack raster skipped – area too large after clamping', { canvasW, canvasH, quality });
         }
-        // If the caller explicitly requested legacy FBM debug delimitations, return a
+        // If the caller explicitly requested legacy noise debug delimitations, return a
         // tiny placeholder raster that includes a coarse `debugRegion` so the
         // UI can still visualize noise buckets even when the full raster is
         // skipped due to clamping limits.
-    if (renderConfig?.showFbmDelimitations && renderConfig?.crackUseNoise) {
+    if (renderConfig?.showNoiseDelimitations && renderConfig?.crackUseNoise) {
             try {
                 const seed = Math.floor((renderConfig?.crackSeed ?? Date.now())) >>> 0;
                 const noiseCfg = renderConfig.crackNoiseParams || { baseScale: 1 / 480, octaves: 4, lacunarity: 2, gain: 0.5, buckets: 3 };
@@ -265,7 +263,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                         const worldPt = (renderConfig && renderConfig.mode === 'isometric')
                             ? { x: screenPt.x, y: screenPt.y }
                             : isoToWorld(screenPt);
-                        const v = fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+                        const v = warpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
                         let id = Math.floor(v * buckets);
                         if (id < 0) id = 0;
                         if (id >= buckets) id = buckets - 1;
@@ -321,7 +319,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     let debug_regionCellW = 0;
     let debug_regionCellH = 0;
     let debug_buckets = 0;
-    const attachDebugRegionRequested = !!(renderConfig && renderConfig.showFbmDelimitations);
+    const attachDebugRegionRequested = !!(renderConfig && renderConfig.showNoiseDelimitations);
     let debugMaskData: Uint8Array | null = null;
     if (debugMask && debugMask.data) {
         if (debugMask.width === width && debugMask.height === height) {
@@ -365,7 +363,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 const worldPt = (renderConfig && renderConfig.mode === 'isometric')
                     ? { x: screenPt.x, y: screenPt.y }
                     : isoToWorld(screenPt);
-                const v = fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale);
+                const v = warpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale);
                 let id = Math.floor(v * buckets);
                 if (id < 0) id = 0;
                 if (id >= buckets) id = buckets - 1;
@@ -381,6 +379,17 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                         countsInMask[id]++;
                     }
                 }
+            }
+        }
+
+        if (renderConfig) {
+            const detectedBuckets: Record<number, number> = {};
+            for (let i = 0; i < countsAll.length; i++) {
+                detectedBuckets[i] = countsAll[i];
+            }
+            (renderConfig as any).detectedNoiseBuckets = detectedBuckets;
+            if ((renderConfig as any).detectedFbmBuckets) {
+                delete (renderConfig as any).detectedFbmBuckets;
             }
         }
 

--- a/src/tools/noiseMask.ts
+++ b/src/tools/noiseMask.ts
@@ -1,7 +1,7 @@
 import { Noise } from 'noisejs';
-import { fbmNoise as _fbmNoise } from './crackGenerator';
+import { warpedSimplexNoise } from './noiseSampler';
 
-export interface FbmMaskOptions {
+export interface NoiseMaskOptions {
     width: number;
     height: number;
     minX: number;
@@ -20,10 +20,11 @@ export interface FbmMaskOptions {
 }
 
 /**
- * Generate a binary (0/255) mask using the same FBM bucket strategy used by the
- * crack generator. Returns a Uint8Array of length width*height where 255 = allowed.
+ * Generate a binary (0/255) mask using the same domain-warped noise bucket
+ * strategy used by the crack generator. Returns a Uint8Array of length
+ * width*height where 255 = allowed.
  */
-export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
+export function generateNoiseMask(opts: NoiseMaskOptions): Uint8Array {
     const width = Math.max(1, Math.round(opts.width));
     const height = Math.max(1, Math.round(opts.height));
     const seed = (typeof opts.seed === 'number') ? (opts.seed >>> 0) : (Date.now() >>> 0);
@@ -49,7 +50,7 @@ export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
             const sampleY = ((ry + 0.5) / regionH) * height;
             const screenPt = { x: sampleX + (opts.minX || 0), y: sampleY + (opts.minY || 0) };
             const worldPt = (opts.mode === 'isometric') ? { x: screenPt.x, y: screenPt.y } : (opts.isoToWorld ? opts.isoToWorld(screenPt) : screenPt);
-            const v = _fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+            const v = warpedSimplexNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
             let id = Math.floor(v * buckets);
             if (id < 0) id = 0;
             if (id >= buckets) id = buckets - 1;
@@ -109,14 +110,14 @@ export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
             const noiseInst = bucketNoise[bucketId];
             const samplePt = { x: x + 0.5 + (opts.minX || 0), y: y + 0.5 + (opts.minY || 0) };
             const worldPt = (opts.mode === 'isometric') ? { x: samplePt.x, y: samplePt.y } : (opts.isoToWorld ? opts.isoToWorld(samplePt) : samplePt);
-            const baseVal = _fbmNoise(noiseInst, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+            const baseVal = warpedSimplexNoise(noiseInst, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
             const dist = Math.abs(baseVal - bucketCenters[bucketId]);
             if (dist > crackBandWidth) {
                 mask[y * width + x] = 0;
                 continue;
             }
             const edge = Math.max(0, (crackBandWidth - dist) / crackBandWidth);
-            const fine = _fbmNoise(noiseInst, worldPt.x * fineScales[bucketId] * 3.0, worldPt.y * fineScales[bucketId] * 3.0, 2, 2, 0.6);
+            const fine = warpedSimplexNoise(noiseInst, worldPt.x * fineScales[bucketId] * 3.0, worldPt.y * fineScales[bucketId] * 3.0, 2, 2, 0.6);
             const modulation = Math.max(0, Math.min(1, Math.pow(edge, 1.2) * (0.35 + 0.65 * fine)));
             const keep = modulation > 0.03; // threshold similar to alpha < 12
             mask[y * width + x] = keep ? 255 : 0;
@@ -126,7 +127,7 @@ export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
     return mask;
 }
 
-export interface FbmRegion {
+export interface NoiseRegion {
     map: Uint8Array;
     w: number;
     h: number;
@@ -137,7 +138,7 @@ export interface FbmRegion {
  * Generate the coarse bucket region map (values 0..buckets-1) without per-pixel
  * band filtering. Useful for visual debugging.
  */
-export function generateFbmRegionMap(opts: FbmMaskOptions): FbmRegion {
+export function generateNoiseRegionMap(opts: NoiseMaskOptions): NoiseRegion {
     const width = Math.max(1, Math.round(opts.width));
     const height = Math.max(1, Math.round(opts.height));
     const seed = (typeof opts.seed === 'number') ? (opts.seed >>> 0) : (Date.now() >>> 0);
@@ -158,7 +159,7 @@ export function generateFbmRegionMap(opts: FbmMaskOptions): FbmRegion {
             const sampleY = ((ry + 0.5) / regionH) * height;
             const screenPt = { x: sampleX + (opts.minX || 0), y: sampleY + (opts.minY || 0) };
             const worldPt = (opts.mode === 'isometric') ? { x: screenPt.x, y: screenPt.y } : (opts.isoToWorld ? opts.isoToWorld(screenPt) : screenPt);
-            const v = _fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+            const v = warpedSimplexNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
             let id = Math.floor(v * buckets);
             if (id < 0) id = 0;
             if (id >= buckets) id = buckets - 1;
@@ -172,7 +173,7 @@ export function generateFbmRegionMap(opts: FbmMaskOptions): FbmRegion {
  * Convert a coarse region map to a visual RGBA image stretched to target width/height.
  * Each bucket gets a simple color; colors are deterministic but arbitrary for debugging.
  */
-export function regionMapToRgbaImage(region: FbmRegion, targetW: number, targetH: number): Uint8ClampedArray {
+export function regionMapToRgbaImage(region: NoiseRegion, targetW: number, targetH: number): Uint8ClampedArray {
     const out = new Uint8ClampedArray(targetW * targetH * 4);
     // simple color palette (repeatable)
     const palette: [number, number, number][] = [

--- a/src/tools/noiseSampler.ts
+++ b/src/tools/noiseSampler.ts
@@ -1,0 +1,47 @@
+import { Noise } from 'noisejs';
+
+/**
+ * Sample a domain-warped simplex noise field mapped to [0, 1].
+ * The number of steps controls how many successive warps are applied.
+ */
+export function warpedSimplexNoise(
+    noise: Noise,
+    x: number,
+    y: number,
+    steps = 3,
+    lacunarity = 2,
+    gain = 0.5,
+): number {
+    const iterations = Math.max(1, Math.floor(steps));
+    let px = x;
+    let py = y;
+    let frequency = 1;
+    let strength = 0.75;
+    for (let i = 0; i < iterations; i++) {
+        const offsetX = 17.27 + i * 11.73;
+        const offsetY = -31.91 + i * 7.53;
+        const warpX = noise.simplex2(px * frequency + offsetX, py * frequency + offsetY);
+        const warpY = noise.simplex2(px * frequency - offsetY, py * frequency + offsetX);
+        px += warpX * strength;
+        py += warpY * strength;
+        frequency *= lacunarity;
+        strength *= gain;
+        if (strength < 1e-4) break;
+    }
+    const value = noise.simplex2(px, py);
+    return value * 0.5 + 0.5;
+}
+
+/**
+ * Convenience helper returning a signed value in the range [-1, 1].
+ */
+export function warpedSimplexNoiseSigned(
+    noise: Noise,
+    x: number,
+    y: number,
+    steps = 3,
+    lacunarity = 2,
+    gain = 0.5,
+): number {
+    return warpedSimplexNoise(noise, x, y, steps, lacunarity, gain) * 2 - 1;
+}


### PR DESCRIPTION
## Summary
- replace the old FBM helpers with a shared domain-warped simplex noise sampler
- update crack generation, zoning, and overlays to use the new sampler and refreshed naming
- rename FBM-specific tooling/UI pieces to generic noise equivalents and expose detected bucket data under the new names

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc88e1decc832a933363c833157d26