### PR TITLE
Replace FBM noise with domain warped sampler

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -787,7 +787,7 @@ const App: React.FC = () => {
                 <div style={{ display: 'inline-block', marginLeft: 12, padding: '6px', border: '1px solid #444', borderRadius: 6 }}>
                     <div style={{ fontSize: 12, fontWeight: 700, marginBottom: 6 }}>Crack Noise</div>
                     <label style={{ fontSize: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="checkbox" checked={crackUseNoise} onChange={(e) => setCrackUseNoise(e.target.checked)} /> Usar fBm para delimitar
+                        <input type="checkbox" checked={crackUseNoise} onChange={(e) => setCrackUseNoise(e.target.checked)} /> Usar ruído distorcido para delimitar
                     </label>
                     <label style={{ fontSize: 12, display: 'flex', alignItems: 'center', gap: 8, marginTop: 6 }}>
                         <input type="checkbox" checked={crashMaskEnabled} onChange={(e) => setCrashMaskEnabled(e.target.checked)} /> Aplicar Crash Mask (apenas nas vias)
@@ -850,11 +850,11 @@ const App: React.FC = () => {
                     <input type="checkbox" checked={Boolean((config as any).render?.debugCrackMask)} onChange={(e) => { (config as any).render = { ...(config as any).render, debugCrackMask: e.target.checked }; setUiTick(t => t + 1); }} /> Show crack mask debug
                 </label>
                 <label style={{ marginLeft: 8, display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-                    <input type="checkbox" checked={Boolean((config as any).render?.showFbmDelimitations)} onChange={(e) => { (config as any).render = { ...(config as any).render, showFbmDelimitations: e.target.checked }; try { localStorage.setItem('showFbmDelimitations', String(e.target.checked)); } catch (e) {} setUiTick(t => t + 1); }} /> Show FBM delimitations
+                    <input type="checkbox" checked={Boolean((config as any).render?.showNoiseDelimitations)} onChange={(e) => { (config as any).render = { ...(config as any).render, showNoiseDelimitations: e.target.checked }; try { localStorage.setItem('showNoiseDelimitations', String(e.target.checked)); } catch (e) {} setUiTick(t => t + 1); }} /> Show noise delimitations
                 </label>
-                {/* Small UI panel showing detected FBM buckets and manual overrides */}
+                {/* Small UI panel showing detected noise buckets and manual overrides */}
                 <div style={{ marginLeft: 8, display: 'inline-flex', alignItems: 'center', gap: 8 }}>
-                    {/* Legend for FBM bucket states */}
+                    {/* Legend for noise bucket states */}
                     <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8, background: 'rgba(0,0,0,0.2)', padding: '6px 8px', borderRadius: 6 }}>
                         <div style={{ display: 'inline-flex', flexDirection: 'column', gap: 4, alignItems: 'flex-start' }}>
                             <div style={{ fontSize: 11, color: '#EEE', fontWeight: 700 }}>Legenda</div>
@@ -879,13 +879,13 @@ const App: React.FC = () => {
                     </div>
                     {(() => {
                         try {
-                            const detected: Record<number, number> | undefined = (config as any).render?.detectedFbmBuckets;
+                            const detected: Record<number, number> | undefined = (config as any).render?.detectedNoiseBuckets;
                             const forced: number[] | undefined = (config as any).render?.forceActiveBucketIds;
                             if (!detected) return null;
                             const ids = Object.keys(detected).map(k => parseInt(k, 10)).filter(n => !isNaN(n)).sort((a,b)=>a-b);
                             return (
                                 <div style={{ display: 'inline-flex', gap: 6, alignItems: 'center', background: 'rgba(0,0,0,0.45)', padding: '6px 8px', borderRadius: 6 }}>
-                                    <div style={{ fontSize: 12, fontWeight: 700, color: '#EEE', marginRight: 6 }}>FBM Buckets</div>
+                                    <div style={{ fontSize: 12, fontWeight: 700, color: '#EEE', marginRight: 6 }}>Noise Buckets</div>
                                     {ids.map(id => {
                                         const count = detected[id] || 0;
                                         const active = Array.isArray(forced) ? forced.indexOf(id) >= 0 : false;

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -285,12 +285,12 @@ export const config = {
     intersectionPatchAlwaysVisibleWithOutlines: true,
     // Mostrar contornos dos quarteirões
     showBlockOutlines: true,
-    // Toggle procedural crash mask (intersection of FBM buckets & road polygons)
+    // Toggle procedural crash mask (intersection of warped-noise buckets & road polygons)
     crashMaskEnabled: false,
     // Crack mask debug/padding controls (UI-adjustable)
     debugCrackMask: false,
-    // Show FBM delimitations (separate toggle for fBm regions / buckets)
-    showFbmDelimitations: false,
+    // Show warped-noise delimitations (separate toggle for noise regions / buckets)
+    showNoiseDelimitations: false,
     // Default padding (px) used for crack mask bounding boxes
     crackMaskPaddingDefault: 4,
     // Extra padding (px) applied when heuristic triggers — fallback default 8
@@ -305,11 +305,11 @@ export const config = {
         dilateRadius: 2,
         quality: 2,
     },
-    // Use Perlin/Fbm noise to distribute cracks instead of masking full roads
+    // Use warped noise to distribute cracks instead of masking full roads
     crackUseNoise: true,
-    // Parâmetros para geração procedural de rachaduras via fBm/Perlin.
+    // Parâmetros para geração procedural de rachaduras via campo de ruído distorcido.
     // - baseScale: frequência base do ruído (1/meters). Valores maiores => manchas maiores.
-    // - octaves/lacunarity/gain: parâmetros de fBm.
+    // - octaves/lacunarity/gain: controlam intensidade e detalhamento da distorção.
     // - buckets: número de regiões quantizadas no mapa de ruído.
     // - crackBandWidth: largura da faixa em torno do centro do bucket que gera rachaduras (0.002..0.1)
     // - maxActiveBuckets: quantos buckets são efetivamente usados para desenhar rachaduras

--- a/src/game_modules/mapgen.ts
+++ b/src/game_modules/mapgen.ts
@@ -216,7 +216,7 @@ let noise: Noise;
 export type ZoneName = 'downtown' | 'residential' | 'commercial' | 'industrial' | 'rural';
 
 export function getZoneAt(p: Point | { x: number; y: number }): ZoneName {
-    // Zonas puramente por Perlin/fBm (independente das ruas)
+    // Zonas puramente por ruído distorcido (independente das ruas)
     return Zoning.zoneAt(p);
 }
 
@@ -637,7 +637,7 @@ export function generate(seed: string | number): MapGenerationResult {
     // Seeded noise instance for deterministic generation
     const noiseSeed = Math.floor(Math.random() * 65536);
     noise = new Noise(noiseSeed);
-    // Inicializar Zoning com perlin fBm antes da criação das ruas
+    // Inicializar Zoning com o novo campo de ruído distorcido antes da criação das ruas
     Zoning.init(noiseSeed);
     // alinhar heatmap próximo da origem (centro inicial da cidade)
     heatmap.calibrateTo({ x: 0, y: 0 });

--- a/src/game_modules/zoning.ts
+++ b/src/game_modules/zoning.ts
@@ -3,6 +3,7 @@ import type { Point } from '../generic_modules/math';
 import type { ZoneName } from './mapgen';
 import { heatmap } from './mapgen';
 import { config } from './config';
+import { sampleWarpedNoise } from '../lib/noiseField';
 
 export type ZoningParams = {
   baseScale: number;
@@ -11,17 +12,6 @@ export type ZoningParams = {
   gain: number;
   thresholds: { r1: number; r2: number; r3: number; r4: number };
 };
-
-function fbm(noise: Noise, x: number, y: number, octaves = 4, lacunarity = 2, gain = 0.5): number {
-  let freq = 1, amp = 1, sum = 0, norm = 0;
-  for (let i = 0; i < octaves; i++) {
-    sum += noise.perlin2(x * freq, y * freq) * amp;
-    norm += amp;
-    freq *= lacunarity;
-    amp *= gain;
-  }
-  return (sum / (norm || 1)) * 0.5 + 0.5;
-}
 
 const Zoning = new (class {
   private _noise: Noise | null = null;
@@ -97,7 +87,7 @@ const Zoning = new (class {
   private _macroNoise(x: number, y: number): number {
     const mn = config.zoningModel.macroNoise;
     if (!this._noise) return 0;
-    return fbm(this._noise, x * mn.baseScale, y * mn.baseScale, mn.octaves, mn.lacunarity, mn.gain) * 2 - 1; // [-1,1]
+    return sampleWarpedNoise(this._noise, x * mn.baseScale, y * mn.baseScale, mn.octaves, mn.lacunarity, mn.gain) * 2 - 1; // [-1,1]
   }
 
   private _scoreProcedural(p: Point): Record<ZoneName, number> {
@@ -153,7 +143,7 @@ const Zoning = new (class {
       else z = 'rural';
   } else if (config.zoningModel.mode === 'perlin') {
       const { baseScale, octaves, lacunarity, gain, thresholds } = this._params;
-      const n = fbm(this._noise, p.x * baseScale, p.y * baseScale, octaves, lacunarity, gain);
+      const n = sampleWarpedNoise(this._noise, p.x * baseScale, p.y * baseScale, octaves, lacunarity, gain);
       if (n < thresholds.r1) z = 'rural';
       else if (n < thresholds.r2) z = 'residential';
       else if (n < thresholds.r3) z = 'commercial';

--- a/src/lib/noiseField.ts
+++ b/src/lib/noiseField.ts
@@ -1,0 +1,81 @@
+import { Noise } from 'noisejs';
+
+export interface WarpedNoiseOptions {
+    /** Strength multiplier applied to the domain warp displacements. */
+    warpStrength?: number;
+    /** Base frequency used by the warp noise fields. */
+    warpScale?: number;
+    /** Number of warp layers applied before sampling the base noise. */
+    warpOctaves?: number;
+    /** Frequency multiplier between warp layers. */
+    warpLacunarity?: number;
+    /** Amplitude multiplier between warp layers. */
+    warpGain?: number;
+    /** Additional layers of detail when sampling the base pattern. */
+    baseLayers?: number;
+    /** Frequency multiplier for base layers. */
+    baseLacunarity?: number;
+    /** Amplitude multiplier for base layers. */
+    baseGain?: number;
+}
+
+const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+
+/**
+ * Sample a 2D noise field using domain-warped Perlin + Simplex noise.
+ *
+ * The goal is to produce organic looking regions without relying on the
+ * traditional layered accumulation that was previously used throughout the
+ * project. Domain warping adds large-scale drifts, while a handful of
+ * base layers provide localized variation.
+ */
+export function sampleWarpedNoise(
+    noise: Noise,
+    x: number,
+    y: number,
+    octaves = 3,
+    lacunarity = 2,
+    gain = 0.5,
+    options: WarpedNoiseOptions = {},
+): number {
+    const warpOctaves = Math.max(1, Math.floor(options.warpOctaves ?? octaves));
+    const warpScale = options.warpScale ?? 0.75;
+    const warpStrengthBase = options.warpStrength ?? 0.65;
+    const warpLacunarity = options.warpLacunarity ?? lacunarity;
+    const warpGain = options.warpGain ?? gain;
+
+    let warpedX = x;
+    let warpedY = y;
+    let warpStrength = warpStrengthBase;
+    let freq = 1;
+    for (let i = 0; i < warpOctaves; i++) {
+        const dx = noise.simplex2((x + 17.13) * warpScale * freq, (y - 41.97) * warpScale * freq);
+        const dy = noise.simplex2((x - 93.11) * warpScale * freq, (y + 26.41) * warpScale * freq);
+        warpedX += dx * warpStrength;
+        warpedY += dy * warpStrength;
+        freq *= warpLacunarity;
+        warpStrength *= warpGain;
+    }
+
+    const baseLayers = Math.max(1, Math.floor(options.baseLayers ?? 2));
+    const baseLacunarity = options.baseLacunarity ?? (lacunarity * 0.85);
+    const baseGain = options.baseGain ?? (gain * 0.9);
+
+    let layerFreq = 1;
+    let layerAmp = 1;
+    let accum = 0;
+    let weight = 0;
+    for (let i = 0; i < baseLayers; i++) {
+        const perlin = noise.perlin2(warpedX * layerFreq, warpedY * layerFreq);
+        const simplex = noise.simplex2((warpedX + 12.7) * layerFreq, (warpedY - 3.8) * layerFreq);
+        const ridge = 1 - Math.abs(perlin);
+        const combined = (perlin * 0.5 + simplex * 0.35 + (ridge * 2 - 1) * 0.15);
+        accum += combined * layerAmp;
+        weight += layerAmp;
+        layerFreq *= baseLacunarity;
+        layerAmp *= baseGain;
+    }
+
+    const normalized = (weight > 0 ? accum / weight : accum) * 0.5 + 0.5;
+    return clamp01(normalized);
+}

--- a/src/overlays/NoiseZoning.ts
+++ b/src/overlays/NoiseZoning.ts
@@ -1,6 +1,6 @@
 /*
  * NoiseZoning Overlay
- * Perlin/fBm-only zoning overlay for city generator
+ * Warped-noise zoning overlay for city generator
  * API: attach(canvas), toggle(), reseed(), redraw()
  * Independent of roads/buildings
  */
@@ -8,22 +8,7 @@ import { ZoneName } from '../game_modules/mapgen';
 import { config } from '../game_modules/config';
 import Zoning from '../game_modules/zoning';
 import { Noise } from 'noisejs';
-
-// Simple Perlin noise implementation (can be replaced by external lib)
-function fbm(noise: Noise, x: number, y: number, octaves = 4, lacunarity = 2, gain = 0.5): number {
-  let freq = 1;
-  let amp = 1;
-  let sum = 0;
-  let norm = 0;
-  for (let i = 0; i < octaves; i++) {
-    sum += noise.perlin2(x * freq, y * freq) * amp;
-    norm += amp;
-    freq *= lacunarity;
-    amp *= gain;
-  }
-  // Map from [-norm, norm] to [0,1]
-  return (sum / (norm || 1)) * 0.5 + 0.5;
-}
+import { sampleWarpedNoise } from '../lib/noiseField';
 
 
 export type NoiseZoningAPI = {
@@ -172,7 +157,7 @@ const NoiseZoning: InternalNoiseZoning = {
         // Mapear pixel -> coordenadas de cena, seguindo pan/zoom
         const Sx = cameraX + (x - cx) / zoom;
         const Sy = cameraY + (y - cy) / zoom;
-        const n = fbm(this._noise, Sx * baseScale, Sy * baseScale, octaves, lacunarity, gain);
+        const n = sampleWarpedNoise(this._noise, Sx * baseScale, Sy * baseScale, octaves, lacunarity, gain);
         let zone: ZoneName = 'residential';
         if (n < thresholds.r1) zone = 'rural';
         else if (n < thresholds.r2) zone = 'residential';

--- a/src/tools/crackGenerator.ts
+++ b/src/tools/crackGenerator.ts
@@ -1,4 +1,5 @@
 import { Noise } from 'noisejs';
+import { sampleWarpedNoise } from '../lib/noiseField';
 
 export interface CrackGeneratorOptions {
     divisions: number;
@@ -16,18 +17,6 @@ function makeRng(seed: number) {
         return state / 0x100000000;
     };
 }
-
-export const fbmNoise = (
-    noise: Noise,
-    x: number,
-    y: number,
-    _octaves = 1,
-    _lacunarity = 2,
-    _gain = 0.5,
-) => {
-    const value = noise.perlin2(x, y);
-    return value * 0.5 + 0.5;
-};
 
 export function generateVoronoiCrackImage(width: number, height: number, options: CrackGeneratorOptions): Uint8ClampedArray {
     const sw = Math.max(1, Math.round(width));
@@ -160,7 +149,7 @@ export interface CrackRaster {
     height: number;
     quality: number;
     color: [number, number, number];
-    // Optional debug info for noise bucket region visualization (legacy FBM naming)
+    // Optional debug info for noise bucket region visualization (legacy naming kept for backwards compatibility)
     debugRegion?: {
         map: Uint8Array;
         w: number;
@@ -240,11 +229,11 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
         if (typeof console !== 'undefined' && console.warn) {
             console.warn('[crackGenerator] Procedural crack raster skipped – area too large after clamping', { canvasW, canvasH, quality });
         }
-        // If the caller explicitly requested legacy FBM debug delimitations, return a
+        // If the caller explicitly requested legacy noise debug delimitations, return a
         // tiny placeholder raster that includes a coarse `debugRegion` so the
         // UI can still visualize noise buckets even when the full raster is
         // skipped due to clamping limits.
-    if (renderConfig?.showFbmDelimitations && renderConfig?.crackUseNoise) {
+    if (renderConfig?.showNoiseDelimitations && renderConfig?.crackUseNoise) {
             try {
                 const seed = Math.floor((renderConfig?.crackSeed ?? Date.now())) >>> 0;
                 const noiseCfg = renderConfig.crackNoiseParams || { baseScale: 1 / 480, octaves: 4, lacunarity: 2, gain: 0.5, buckets: 3 };
@@ -265,7 +254,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                         const worldPt = (renderConfig && renderConfig.mode === 'isometric')
                             ? { x: screenPt.x, y: screenPt.y }
                             : isoToWorld(screenPt);
-                        const v = fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+                        const v = sampleWarpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
                         let id = Math.floor(v * buckets);
                         if (id < 0) id = 0;
                         if (id >= buckets) id = buckets - 1;
@@ -321,7 +310,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     let debug_regionCellW = 0;
     let debug_regionCellH = 0;
     let debug_buckets = 0;
-    const attachDebugRegionRequested = !!(renderConfig && renderConfig.showFbmDelimitations);
+    const attachDebugRegionRequested = !!(renderConfig && renderConfig.showNoiseDelimitations);
     let debugMaskData: Uint8Array | null = null;
     if (debugMask && debugMask.data) {
         if (debugMask.width === width && debugMask.height === height) {
@@ -365,7 +354,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 const worldPt = (renderConfig && renderConfig.mode === 'isometric')
                     ? { x: screenPt.x, y: screenPt.y }
                     : isoToWorld(screenPt);
-                const v = fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale);
+                const v = sampleWarpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale);
                 let id = Math.floor(v * buckets);
                 if (id < 0) id = 0;
                 if (id >= buckets) id = buckets - 1;

--- a/src/tools/noiseMask.ts
+++ b/src/tools/noiseMask.ts
@@ -1,7 +1,7 @@
 import { Noise } from 'noisejs';
-import { fbmNoise as _fbmNoise } from './crackGenerator';
+import { sampleWarpedNoise } from '../lib/noiseField';
 
-export interface FbmMaskOptions {
+export interface NoiseMaskOptions {
     width: number;
     height: number;
     minX: number;
@@ -20,10 +20,10 @@ export interface FbmMaskOptions {
 }
 
 /**
- * Generate a binary (0/255) mask using the same FBM bucket strategy used by the
- * crack generator. Returns a Uint8Array of length width*height where 255 = allowed.
+ * Generate a binary (0/255) mask using the same warped-noise bucket strategy used by
+ * the crack generator. Returns a Uint8Array of length width*height where 255 = allowed.
  */
-export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
+export function generateNoiseMask(opts: NoiseMaskOptions): Uint8Array {
     const width = Math.max(1, Math.round(opts.width));
     const height = Math.max(1, Math.round(opts.height));
     const seed = (typeof opts.seed === 'number') ? (opts.seed >>> 0) : (Date.now() >>> 0);
@@ -49,7 +49,7 @@ export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
             const sampleY = ((ry + 0.5) / regionH) * height;
             const screenPt = { x: sampleX + (opts.minX || 0), y: sampleY + (opts.minY || 0) };
             const worldPt = (opts.mode === 'isometric') ? { x: screenPt.x, y: screenPt.y } : (opts.isoToWorld ? opts.isoToWorld(screenPt) : screenPt);
-            const v = _fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+            const v = sampleWarpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
             let id = Math.floor(v * buckets);
             if (id < 0) id = 0;
             if (id >= buckets) id = buckets - 1;
@@ -109,14 +109,14 @@ export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
             const noiseInst = bucketNoise[bucketId];
             const samplePt = { x: x + 0.5 + (opts.minX || 0), y: y + 0.5 + (opts.minY || 0) };
             const worldPt = (opts.mode === 'isometric') ? { x: samplePt.x, y: samplePt.y } : (opts.isoToWorld ? opts.isoToWorld(samplePt) : samplePt);
-            const baseVal = _fbmNoise(noiseInst, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+            const baseVal = sampleWarpedNoise(noiseInst, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
             const dist = Math.abs(baseVal - bucketCenters[bucketId]);
             if (dist > crackBandWidth) {
                 mask[y * width + x] = 0;
                 continue;
             }
             const edge = Math.max(0, (crackBandWidth - dist) / crackBandWidth);
-            const fine = _fbmNoise(noiseInst, worldPt.x * fineScales[bucketId] * 3.0, worldPt.y * fineScales[bucketId] * 3.0, 2, 2, 0.6);
+            const fine = sampleWarpedNoise(noiseInst, worldPt.x * fineScales[bucketId] * 3.0, worldPt.y * fineScales[bucketId] * 3.0, 2, 2, 0.6);
             const modulation = Math.max(0, Math.min(1, Math.pow(edge, 1.2) * (0.35 + 0.65 * fine)));
             const keep = modulation > 0.03; // threshold similar to alpha < 12
             mask[y * width + x] = keep ? 255 : 0;
@@ -126,7 +126,7 @@ export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
     return mask;
 }
 
-export interface FbmRegion {
+export interface NoiseRegion {
     map: Uint8Array;
     w: number;
     h: number;
@@ -137,7 +137,7 @@ export interface FbmRegion {
  * Generate the coarse bucket region map (values 0..buckets-1) without per-pixel
  * band filtering. Useful for visual debugging.
  */
-export function generateFbmRegionMap(opts: FbmMaskOptions): FbmRegion {
+export function generateNoiseRegionMap(opts: NoiseMaskOptions): NoiseRegion {
     const width = Math.max(1, Math.round(opts.width));
     const height = Math.max(1, Math.round(opts.height));
     const seed = (typeof opts.seed === 'number') ? (opts.seed >>> 0) : (Date.now() >>> 0);
@@ -158,7 +158,7 @@ export function generateFbmRegionMap(opts: FbmMaskOptions): FbmRegion {
             const sampleY = ((ry + 0.5) / regionH) * height;
             const screenPt = { x: sampleX + (opts.minX || 0), y: sampleY + (opts.minY || 0) };
             const worldPt = (opts.mode === 'isometric') ? { x: screenPt.x, y: screenPt.y } : (opts.isoToWorld ? opts.isoToWorld(screenPt) : screenPt);
-            const v = _fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+            const v = sampleWarpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
             let id = Math.floor(v * buckets);
             if (id < 0) id = 0;
             if (id >= buckets) id = buckets - 1;
@@ -172,7 +172,7 @@ export function generateFbmRegionMap(opts: FbmMaskOptions): FbmRegion {
  * Convert a coarse region map to a visual RGBA image stretched to target width/height.
  * Each bucket gets a simple color; colors are deterministic but arbitrary for debugging.
  */
-export function regionMapToRgbaImage(region: FbmRegion, targetW: number, targetH: number): Uint8ClampedArray {
+export function regionMapToRgbaImage(region: NoiseRegion, targetW: number, targetH: number): Uint8ClampedArray {
     const out = new Uint8ClampedArray(targetW * targetH * 4);
     // simple color palette (repeatable)
     const palette: [number, number, number][] = [


### PR DESCRIPTION
## Summary
- add a reusable domain-warped noise sampler and switch crack generation to it
- migrate the crack mask utilities and zoning systems to the new noise naming and sampler
- refresh UI labels and config flags to drop the old FBM terminology

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc88e1decc832a933363c833157d26