### PR TITLE
Restore crack noise delineation overlay

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -787,7 +787,7 @@ const App: React.FC = () => {
                 <div style={{ display: 'inline-block', marginLeft: 12, padding: '6px', border: '1px solid #444', borderRadius: 6 }}>
                     <div style={{ fontSize: 12, fontWeight: 700, marginBottom: 6 }}>Crack Noise</div>
                     <label style={{ fontSize: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="checkbox" checked={crackUseNoise} onChange={(e) => setCrackUseNoise(e.target.checked)} /> Usar fBm para delimitar
+                        <input type="checkbox" checked={crackUseNoise} onChange={(e) => setCrackUseNoise(e.target.checked)} /> Usar ruído distorcido para delimitar
                     </label>
                     <label style={{ fontSize: 12, display: 'flex', alignItems: 'center', gap: 8, marginTop: 6 }}>
                         <input type="checkbox" checked={crashMaskEnabled} onChange={(e) => setCrashMaskEnabled(e.target.checked)} /> Aplicar Crash Mask (apenas nas vias)
@@ -850,11 +850,11 @@ const App: React.FC = () => {
                     <input type="checkbox" checked={Boolean((config as any).render?.debugCrackMask)} onChange={(e) => { (config as any).render = { ...(config as any).render, debugCrackMask: e.target.checked }; setUiTick(t => t + 1); }} /> Show crack mask debug
                 </label>
                 <label style={{ marginLeft: 8, display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-                    <input type="checkbox" checked={Boolean((config as any).render?.showFbmDelimitations)} onChange={(e) => { (config as any).render = { ...(config as any).render, showFbmDelimitations: e.target.checked }; try { localStorage.setItem('showFbmDelimitations', String(e.target.checked)); } catch (e) {} setUiTick(t => t + 1); }} /> Show FBM delimitations
+                    <input type="checkbox" checked={Boolean((config as any).render?.showNoiseDelimitations)} onChange={(e) => { (config as any).render = { ...(config as any).render, showNoiseDelimitations: e.target.checked }; try { localStorage.setItem('showNoiseDelimitations', String(e.target.checked)); } catch (e) {} setUiTick(t => t + 1); }} /> Show noise delimitations
                 </label>
-                {/* Small UI panel showing detected FBM buckets and manual overrides */}
+                {/* Small UI panel showing detected noise buckets and manual overrides */}
                 <div style={{ marginLeft: 8, display: 'inline-flex', alignItems: 'center', gap: 8 }}>
-                    {/* Legend for FBM bucket states */}
+                    {/* Legend for noise bucket states */}
                     <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8, background: 'rgba(0,0,0,0.2)', padding: '6px 8px', borderRadius: 6 }}>
                         <div style={{ display: 'inline-flex', flexDirection: 'column', gap: 4, alignItems: 'flex-start' }}>
                             <div style={{ fontSize: 11, color: '#EEE', fontWeight: 700 }}>Legenda</div>
@@ -879,13 +879,13 @@ const App: React.FC = () => {
                     </div>
                     {(() => {
                         try {
-                            const detected: Record<number, number> | undefined = (config as any).render?.detectedFbmBuckets;
+                            const detected: Record<number, number> | undefined = (config as any).render?.detectedNoiseBuckets;
                             const forced: number[] | undefined = (config as any).render?.forceActiveBucketIds;
                             if (!detected) return null;
                             const ids = Object.keys(detected).map(k => parseInt(k, 10)).filter(n => !isNaN(n)).sort((a,b)=>a-b);
                             return (
                                 <div style={{ display: 'inline-flex', gap: 6, alignItems: 'center', background: 'rgba(0,0,0,0.45)', padding: '6px 8px', borderRadius: 6 }}>
-                                    <div style={{ fontSize: 12, fontWeight: 700, color: '#EEE', marginRight: 6 }}>FBM Buckets</div>
+                                    <div style={{ fontSize: 12, fontWeight: 700, color: '#EEE', marginRight: 6 }}>Noise Buckets</div>
                                     {ids.map(id => {
                                         const count = detected[id] || 0;
                                         const active = Array.isArray(forced) ? forced.indexOf(id) >= 0 : false;

--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -201,6 +201,72 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
         return graphics;
     };
 
+    const noiseBucketPalette: Array<[number, number, number]> = [
+        [220, 38, 38],
+        [34, 197, 94],
+        [37, 99, 235],
+        [234, 179, 8],
+        [168, 85, 247],
+        [16, 185, 129],
+        [251, 191, 36],
+        [244, 63, 94],
+    ];
+
+    const buildNoiseRegionOverlay = (
+        region: NonNullable<CrackRaster['debugRegion']>,
+        spriteW: number,
+        spriteH: number,
+        renderCfg: any,
+    ): PIXI.Graphics | null => {
+        if (!region || !region.map || region.map.length === 0 || region.w <= 0 || region.h <= 0) return null;
+        const cellW = (typeof region.cellW === 'number' && isFinite(region.cellW) && region.cellW > 0)
+            ? region.cellW
+            : (region.w > 0 ? spriteW / region.w : spriteW);
+        const cellH = (typeof region.cellH === 'number' && isFinite(region.cellH) && region.cellH > 0)
+            ? region.cellH
+            : (region.h > 0 ? spriteH / region.h : spriteH);
+        const activeSet = new Set<number>();
+        if (Array.isArray(region.activeBuckets)) {
+            for (const v of region.activeBuckets) {
+                const n = Math.floor(Number(v));
+                if (isFinite(n)) activeSet.add(n);
+            }
+        }
+        const highlightActive = activeSet.size > 0;
+        const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+        const activeAlpha = clamp01(typeof renderCfg?.noiseDelimActiveAlpha === 'number' ? renderCfg.noiseDelimActiveAlpha : 0.28);
+        const inactiveAlphaDefault = activeAlpha * 0.35;
+        const inactiveAlpha = clamp01(typeof renderCfg?.noiseDelimInactiveAlpha === 'number' ? renderCfg.noiseDelimInactiveAlpha : inactiveAlphaDefault);
+        const borderAlpha = clamp01(typeof renderCfg?.noiseDelimBorderAlpha === 'number' ? renderCfg.noiseDelimBorderAlpha : 0.5);
+        const inactiveBorderAlpha = clamp01(typeof renderCfg?.noiseDelimBorderInactiveAlpha === 'number'
+            ? renderCfg.noiseDelimBorderInactiveAlpha
+            : borderAlpha * 0.5);
+        const toHex = (col: [number, number, number]) => ((col[0] & 0xFF) << 16) | ((col[1] & 0xFF) << 8) | (col[2] & 0xFF);
+        const overlay = new PIXI.Graphics();
+        const minDim = Math.max(0.5, Math.min(cellW, cellH));
+        const borderWidth = Math.max(1, Math.round(minDim * 0.08));
+        for (let ry = 0; ry < region.h; ry++) {
+            for (let rx = 0; rx < region.w; rx++) {
+                const idx = ry * region.w + rx;
+                const bucketId = region.map[idx] ?? 0;
+                const isActive = !highlightActive || activeSet.has(bucketId);
+                const fillAlpha = isActive ? activeAlpha : inactiveAlpha;
+                if (fillAlpha <= 0) continue;
+                const paletteCol = noiseBucketPalette[bucketId % noiseBucketPalette.length];
+                const x0 = rx * cellW;
+                const y0 = ry * cellH;
+                const x1 = rx === region.w - 1 ? spriteW : (rx + 1) * cellW;
+                const y1 = ry === region.h - 1 ? spriteH : (ry + 1) * cellH;
+                overlay.lineStyle(borderWidth, isActive ? 0xFFFFFF : 0x000000, isActive ? borderAlpha : inactiveBorderAlpha, 0, true);
+                overlay.beginFill(toHex(paletteCol), fillAlpha);
+                overlay.drawRect(x0, y0, Math.max(0.5, x1 - x0), Math.max(0.5, y1 - y0));
+                overlay.endFill();
+            }
+        }
+        try { overlay.cacheAsBitmap = true; } catch (e) {}
+        return overlay;
+    };
+
     const maskToGraphics = (
         mask: Uint8Array | null,
         maskWidth: number,
@@ -2151,6 +2217,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                     const wantCrashMaskDebug = !!(renderCfg.debugCrackMask);
                     const shouldBuildCrashMask = (crashMaskActive || wantCrashMaskDebug) && polys.length > 0;
                     let polygonMask: Uint8Array | null = null;
+                    let noiseDebugRegion: CrackRaster['debugRegion'] | null = null;
                     if (shouldBuildCrashMask) {
                         try {
                             polygonMask = buildPolygonMask(polys, spriteW, spriteH, minX, minY);
@@ -2171,6 +2238,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                             captureCrashMask: crashMaskActive || wantCrashMaskDebug,
                         });
                         if (raster) {
+                            noiseDebugRegion = raster.debugRegion || null;
                             const alphaMultiplier = (typeof roadCrackAlpha === 'number' && isFinite(roadCrackAlpha)) ? roadCrackAlpha : 1;
                             const graphics = rasterToGraphics(raster, spriteW, spriteH, alphaMultiplier);
                             if (graphics) {
@@ -2237,16 +2305,30 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                         cracksDisplay = sprite;
                     }
 
+                    const container = new PIXI.Container();
+                    container.x = minX;
+                    container.y = minY;
+                    let containerChildren = 0;
+                    if (renderCfg.showNoiseDelimitations && noiseDebugRegion) {
+                        const noiseOverlay = buildNoiseRegionOverlay(noiseDebugRegion, spriteW, spriteH, renderCfg);
+                        if (noiseOverlay) {
+                            noiseOverlay.x = 0;
+                            noiseOverlay.y = 0;
+                            container.addChild(noiseOverlay);
+                            containerChildren++;
+                        }
+                    }
                     if (cracksDisplay) {
-                        const container = new PIXI.Container();
-                        container.x = minX;
-                        container.y = minY;
                         cracksDisplay.x = 0;
                         cracksDisplay.y = 0;
                         container.addChild(cracksDisplay);
-                        if (crashMaskDebugGraphics) {
-                            container.addChild(crashMaskDebugGraphics);
-                        }
+                        containerChildren++;
+                    }
+                    if (crashMaskDebugGraphics) {
+                        container.addChild(crashMaskDebugGraphics);
+                        containerChildren++;
+                    }
+                    if (containerChildren > 0) {
                         container.addChild(maskG);
                         container.mask = maskG;
                         roadCrackOverlay.current?.addChild(container);

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -285,12 +285,12 @@ export const config = {
     intersectionPatchAlwaysVisibleWithOutlines: true,
     // Mostrar contornos dos quarteirões
     showBlockOutlines: true,
-    // Toggle procedural crash mask (intersection of FBM buckets & road polygons)
+    // Toggle procedural crash mask (intersection of warped-noise buckets & road polygons)
     crashMaskEnabled: false,
     // Crack mask debug/padding controls (UI-adjustable)
     debugCrackMask: false,
-    // Show FBM delimitations (separate toggle for fBm regions / buckets)
-    showFbmDelimitations: false,
+    // Show warped-noise delimitations (separate toggle for noise regions / buckets)
+    showNoiseDelimitations: false,
     // Default padding (px) used for crack mask bounding boxes
     crackMaskPaddingDefault: 4,
     // Extra padding (px) applied when heuristic triggers — fallback default 8
@@ -305,11 +305,11 @@ export const config = {
         dilateRadius: 2,
         quality: 2,
     },
-    // Use Perlin/Fbm noise to distribute cracks instead of masking full roads
+    // Use warped noise to distribute cracks instead of masking full roads
     crackUseNoise: true,
-    // Parâmetros para geração procedural de rachaduras via fBm/Perlin.
+    // Parâmetros para geração procedural de rachaduras via campo de ruído distorcido.
     // - baseScale: frequência base do ruído (1/meters). Valores maiores => manchas maiores.
-    // - octaves/lacunarity/gain: parâmetros de fBm.
+    // - octaves/lacunarity/gain: controlam intensidade e detalhamento da distorção.
     // - buckets: número de regiões quantizadas no mapa de ruído.
     // - crackBandWidth: largura da faixa em torno do centro do bucket que gera rachaduras (0.002..0.1)
     // - maxActiveBuckets: quantos buckets são efetivamente usados para desenhar rachaduras

--- a/src/game_modules/mapgen.ts
+++ b/src/game_modules/mapgen.ts
@@ -216,7 +216,7 @@ let noise: Noise;
 export type ZoneName = 'downtown' | 'residential' | 'commercial' | 'industrial' | 'rural';
 
 export function getZoneAt(p: Point | { x: number; y: number }): ZoneName {
-    // Zonas puramente por Perlin/fBm (independente das ruas)
+    // Zonas puramente por ruído distorcido (independente das ruas)
     return Zoning.zoneAt(p);
 }
 
@@ -637,7 +637,7 @@ export function generate(seed: string | number): MapGenerationResult {
     // Seeded noise instance for deterministic generation
     const noiseSeed = Math.floor(Math.random() * 65536);
     noise = new Noise(noiseSeed);
-    // Inicializar Zoning com perlin fBm antes da criação das ruas
+    // Inicializar Zoning com o novo campo de ruído distorcido antes da criação das ruas
     Zoning.init(noiseSeed);
     // alinhar heatmap próximo da origem (centro inicial da cidade)
     heatmap.calibrateTo({ x: 0, y: 0 });

--- a/src/game_modules/zoning.ts
+++ b/src/game_modules/zoning.ts
@@ -3,6 +3,7 @@ import type { Point } from '../generic_modules/math';
 import type { ZoneName } from './mapgen';
 import { heatmap } from './mapgen';
 import { config } from './config';
+import { sampleWarpedNoise } from '../lib/noiseField';
 
 export type ZoningParams = {
   baseScale: number;
@@ -11,17 +12,6 @@ export type ZoningParams = {
   gain: number;
   thresholds: { r1: number; r2: number; r3: number; r4: number };
 };
-
-function fbm(noise: Noise, x: number, y: number, octaves = 4, lacunarity = 2, gain = 0.5): number {
-  let freq = 1, amp = 1, sum = 0, norm = 0;
-  for (let i = 0; i < octaves; i++) {
-    sum += noise.perlin2(x * freq, y * freq) * amp;
-    norm += amp;
-    freq *= lacunarity;
-    amp *= gain;
-  }
-  return (sum / (norm || 1)) * 0.5 + 0.5;
-}
 
 const Zoning = new (class {
   private _noise: Noise | null = null;
@@ -97,7 +87,7 @@ const Zoning = new (class {
   private _macroNoise(x: number, y: number): number {
     const mn = config.zoningModel.macroNoise;
     if (!this._noise) return 0;
-    return fbm(this._noise, x * mn.baseScale, y * mn.baseScale, mn.octaves, mn.lacunarity, mn.gain) * 2 - 1; // [-1,1]
+    return sampleWarpedNoise(this._noise, x * mn.baseScale, y * mn.baseScale, mn.octaves, mn.lacunarity, mn.gain) * 2 - 1; // [-1,1]
   }
 
   private _scoreProcedural(p: Point): Record<ZoneName, number> {
@@ -153,7 +143,7 @@ const Zoning = new (class {
       else z = 'rural';
   } else if (config.zoningModel.mode === 'perlin') {
       const { baseScale, octaves, lacunarity, gain, thresholds } = this._params;
-      const n = fbm(this._noise, p.x * baseScale, p.y * baseScale, octaves, lacunarity, gain);
+      const n = sampleWarpedNoise(this._noise, p.x * baseScale, p.y * baseScale, octaves, lacunarity, gain);
       if (n < thresholds.r1) z = 'rural';
       else if (n < thresholds.r2) z = 'residential';
       else if (n < thresholds.r3) z = 'commercial';

--- a/src/lib/noiseField.ts
+++ b/src/lib/noiseField.ts
@@ -1,0 +1,81 @@
+import { Noise } from 'noisejs';
+
+export interface WarpedNoiseOptions {
+    /** Strength multiplier applied to the domain warp displacements. */
+    warpStrength?: number;
+    /** Base frequency used by the warp noise fields. */
+    warpScale?: number;
+    /** Number of warp layers applied before sampling the base noise. */
+    warpOctaves?: number;
+    /** Frequency multiplier between warp layers. */
+    warpLacunarity?: number;
+    /** Amplitude multiplier between warp layers. */
+    warpGain?: number;
+    /** Additional layers of detail when sampling the base pattern. */
+    baseLayers?: number;
+    /** Frequency multiplier for base layers. */
+    baseLacunarity?: number;
+    /** Amplitude multiplier for base layers. */
+    baseGain?: number;
+}
+
+const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+
+/**
+ * Sample a 2D noise field using domain-warped Perlin + Simplex noise.
+ *
+ * The goal is to produce organic looking regions without relying on the
+ * traditional layered accumulation that was previously used throughout the
+ * project. Domain warping adds large-scale drifts, while a handful of
+ * base layers provide localized variation.
+ */
+export function sampleWarpedNoise(
+    noise: Noise,
+    x: number,
+    y: number,
+    octaves = 3,
+    lacunarity = 2,
+    gain = 0.5,
+    options: WarpedNoiseOptions = {},
+): number {
+    const warpOctaves = Math.max(1, Math.floor(options.warpOctaves ?? octaves));
+    const warpScale = options.warpScale ?? 0.75;
+    const warpStrengthBase = options.warpStrength ?? 0.65;
+    const warpLacunarity = options.warpLacunarity ?? lacunarity;
+    const warpGain = options.warpGain ?? gain;
+
+    let warpedX = x;
+    let warpedY = y;
+    let warpStrength = warpStrengthBase;
+    let freq = 1;
+    for (let i = 0; i < warpOctaves; i++) {
+        const dx = noise.simplex2((x + 17.13) * warpScale * freq, (y - 41.97) * warpScale * freq);
+        const dy = noise.simplex2((x - 93.11) * warpScale * freq, (y + 26.41) * warpScale * freq);
+        warpedX += dx * warpStrength;
+        warpedY += dy * warpStrength;
+        freq *= warpLacunarity;
+        warpStrength *= warpGain;
+    }
+
+    const baseLayers = Math.max(1, Math.floor(options.baseLayers ?? 2));
+    const baseLacunarity = options.baseLacunarity ?? (lacunarity * 0.85);
+    const baseGain = options.baseGain ?? (gain * 0.9);
+
+    let layerFreq = 1;
+    let layerAmp = 1;
+    let accum = 0;
+    let weight = 0;
+    for (let i = 0; i < baseLayers; i++) {
+        const perlin = noise.perlin2(warpedX * layerFreq, warpedY * layerFreq);
+        const simplex = noise.simplex2((warpedX + 12.7) * layerFreq, (warpedY - 3.8) * layerFreq);
+        const ridge = 1 - Math.abs(perlin);
+        const combined = (perlin * 0.5 + simplex * 0.35 + (ridge * 2 - 1) * 0.15);
+        accum += combined * layerAmp;
+        weight += layerAmp;
+        layerFreq *= baseLacunarity;
+        layerAmp *= baseGain;
+    }
+
+    const normalized = (weight > 0 ? accum / weight : accum) * 0.5 + 0.5;
+    return clamp01(normalized);
+}

--- a/src/overlays/NoiseZoning.ts
+++ b/src/overlays/NoiseZoning.ts
@@ -1,6 +1,6 @@
 /*
  * NoiseZoning Overlay
- * Perlin/fBm-only zoning overlay for city generator
+ * Warped-noise zoning overlay for city generator
  * API: attach(canvas), toggle(), reseed(), redraw()
  * Independent of roads/buildings
  */
@@ -8,22 +8,7 @@ import { ZoneName } from '../game_modules/mapgen';
 import { config } from '../game_modules/config';
 import Zoning from '../game_modules/zoning';
 import { Noise } from 'noisejs';
-
-// Simple Perlin noise implementation (can be replaced by external lib)
-function fbm(noise: Noise, x: number, y: number, octaves = 4, lacunarity = 2, gain = 0.5): number {
-  let freq = 1;
-  let amp = 1;
-  let sum = 0;
-  let norm = 0;
-  for (let i = 0; i < octaves; i++) {
-    sum += noise.perlin2(x * freq, y * freq) * amp;
-    norm += amp;
-    freq *= lacunarity;
-    amp *= gain;
-  }
-  // Map from [-norm, norm] to [0,1]
-  return (sum / (norm || 1)) * 0.5 + 0.5;
-}
+import { sampleWarpedNoise } from '../lib/noiseField';
 
 
 export type NoiseZoningAPI = {
@@ -172,7 +157,7 @@ const NoiseZoning: InternalNoiseZoning = {
         // Mapear pixel -> coordenadas de cena, seguindo pan/zoom
         const Sx = cameraX + (x - cx) / zoom;
         const Sy = cameraY + (y - cy) / zoom;
-        const n = fbm(this._noise, Sx * baseScale, Sy * baseScale, octaves, lacunarity, gain);
+        const n = sampleWarpedNoise(this._noise, Sx * baseScale, Sy * baseScale, octaves, lacunarity, gain);
         let zone: ZoneName = 'residential';
         if (n < thresholds.r1) zone = 'rural';
         else if (n < thresholds.r2) zone = 'residential';

--- a/src/tools/crackGenerator.ts
+++ b/src/tools/crackGenerator.ts
@@ -1,4 +1,5 @@
 import { Noise } from 'noisejs';
+import { sampleWarpedNoise } from '../lib/noiseField';
 
 export interface CrackGeneratorOptions {
     divisions: number;
@@ -16,18 +17,6 @@ function makeRng(seed: number) {
         return state / 0x100000000;
     };
 }
-
-export const fbmNoise = (
-    noise: Noise,
-    x: number,
-    y: number,
-    _octaves = 1,
-    _lacunarity = 2,
-    _gain = 0.5,
-) => {
-    const value = noise.perlin2(x, y);
-    return value * 0.5 + 0.5;
-};
 
 export function generateVoronoiCrackImage(width: number, height: number, options: CrackGeneratorOptions): Uint8ClampedArray {
     const sw = Math.max(1, Math.round(width));
@@ -160,7 +149,7 @@ export interface CrackRaster {
     height: number;
     quality: number;
     color: [number, number, number];
-    // Optional debug info for noise bucket region visualization (legacy FBM naming)
+    // Optional debug info for noise bucket region visualization (legacy naming kept for backwards compatibility)
     debugRegion?: {
         map: Uint8Array;
         w: number;
@@ -171,6 +160,9 @@ export interface CrackRaster {
         minX: number;
         minY: number;
         quality: number;
+        activeBuckets?: number[];
+        countsAll?: number[];
+        countsInMask?: number[];
     };
     crashMask?: {
         data: Uint8Array;
@@ -207,6 +199,15 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     const width = Math.max(1, Math.round(widthRaw));
     const height = Math.max(1, Math.round(heightRaw));
     const crackCfg = renderConfig?.crackProceduralParams || {};
+    if (renderConfig) {
+        try {
+            delete (renderConfig as any).detectedNoiseBuckets;
+            delete (renderConfig as any).detectedNoiseBucketsInMask;
+            delete (renderConfig as any).activeNoiseBucketIds;
+        } catch (e) {
+            // ignore property cleanup errors (e.g., sealed objects)
+        }
+    }
     const fallbackQuality = (typeof crackCfg.quality === 'number' && isFinite(crackCfg.quality))
         ? crackCfg.quality
         : ((typeof window !== 'undefined' && typeof window.devicePixelRatio === 'number') ? window.devicePixelRatio : 1);
@@ -226,6 +227,82 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
         canvasH = Math.max(1, Math.round(height * quality));
     };
 
+
+    let debugMaskData: Uint8Array | null = null;
+    if (debugMask && debugMask.data) {
+        if (debugMask.width === width && debugMask.height === height) {
+            debugMaskData = debugMask.data;
+        } else if (typeof console !== 'undefined' && console.warn) {
+            console.warn('[crackGenerator] Ignoring debugMask due to dimension mismatch', {
+                expected: { width, height }, provided: { width: debugMask.width, height: debugMask.height }
+            });
+        }
+    }
+
+    const selectActiveBuckets = (
+        countsAll: number[],
+        countsInMask: number[],
+        buckets: number,
+        maxActive: number,
+        strategy: string,
+        seedValue: number,
+        debugMaskArr: Uint8Array | null,
+    ) => {
+        const statsAll = countsAll.map((c, i) => ({ i, c }));
+        const statsMask = countsInMask.map((c, i) => ({ i, c }));
+        const positiveMask = statsMask.filter(s => s.c > 0);
+        const positiveAll = statsAll.filter(s => s.c > 0);
+        const selectionPool = debugMaskArr
+            ? (positiveMask.length > 0 ? positiveMask : (positiveAll.length > 0 ? positiveAll : statsMask))
+            : (positiveAll.length > 0 ? positiveAll : statsAll);
+        const rng = (() => {
+            let t = (seedValue ^ 0x9E3779B9) >>> 0;
+            return () => {
+                t = (t * 1664525 + 1013904223) >>> 0;
+                return t / 0x100000000;
+            };
+        })();
+        const pickByStrategy = (pool: { i: number; c: number }[], count: number) => {
+            if (pool.length === 0 || count <= 0) return [] as { i: number; c: number }[];
+            if (strategy === 'largest') {
+                return pool.slice().sort((a, b) => (b.c - a.c) || (a.i - b.i)).slice(0, count);
+            }
+            if (strategy === 'random') {
+                const arr = pool.slice();
+                for (let i = arr.length - 1; i > 0; i--) {
+                    const j = Math.floor(rng() * (i + 1));
+                    const tmp = arr[i];
+                    arr[i] = arr[j];
+                    arr[j] = tmp;
+                }
+                return arr.slice(0, count);
+            }
+            return pool.slice().sort((a, b) => (a.c - b.c) || (a.i - b.i)).slice(0, count);
+        };
+
+        let picked = pickByStrategy(selectionPool, maxActive);
+        if (picked.length < maxActive) {
+            const fallbackPoolBase = positiveAll.length > 0 ? positiveAll : statsAll;
+            const fallbackPool = fallbackPoolBase.filter(item => !picked.some(p => p.i === item.i));
+            const extra = pickByStrategy(
+                fallbackPool.length > 0 ? fallbackPool : statsAll.filter(item => !picked.some(p => p.i === item.i)),
+                maxActive - picked.length,
+            );
+            picked = picked.concat(extra);
+        }
+        if (picked.length < maxActive) {
+            for (let b = 0; picked.length < maxActive && b < buckets; b++) {
+                if (picked.some(p => p.i === b)) continue;
+                picked.push({ i: b, c: 0 });
+            }
+        }
+        const active = new Set<number>(picked.map(p => p.i));
+        if (active.size === 0) {
+            for (let b = 0; b < buckets; b++) active.add(b);
+        }
+        return { active, statsAll, statsMask, picked };
+    };
+
     if (canvasW > maxCanvasDimension || canvasH > maxCanvasDimension) {
         const factor = Math.max(canvasW / maxCanvasDimension, canvasH / maxCanvasDimension);
         applyQualityReduction(factor);
@@ -240,11 +317,11 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
         if (typeof console !== 'undefined' && console.warn) {
             console.warn('[crackGenerator] Procedural crack raster skipped – area too large after clamping', { canvasW, canvasH, quality });
         }
-        // If the caller explicitly requested legacy FBM debug delimitations, return a
+        // If the caller explicitly requested legacy noise debug delimitations, return a
         // tiny placeholder raster that includes a coarse `debugRegion` so the
         // UI can still visualize noise buckets even when the full raster is
         // skipped due to clamping limits.
-    if (renderConfig?.showFbmDelimitations && renderConfig?.crackUseNoise) {
+    if (renderConfig?.showNoiseDelimitations && renderConfig?.crackUseNoise) {
             try {
                 const seed = Math.floor((renderConfig?.crackSeed ?? Date.now())) >>> 0;
                 const noiseCfg = renderConfig.crackNoiseParams || { baseScale: 1 / 480, octaves: 4, lacunarity: 2, gain: 0.5, buckets: 3 };
@@ -253,10 +330,14 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 const lacunarity = noiseCfg.lacunarity || 2;
                 const gain = noiseCfg.gain || 0.5;
                 const buckets = Math.max(1, Math.min(8, noiseCfg.buckets || 3));
+                const maxActive = Math.max(1, Math.min(buckets, noiseCfg.maxActiveBuckets || 2));
+                const strategy = noiseCfg.activeBucketStrategy || 'smallest';
                 const debug_regionW = Math.max(4, Math.min(64, Math.floor(Math.min(width, height) / 32) || 8));
                 const debug_regionH = Math.max(4, Math.min(64, Math.floor(Math.min(width, height) / 32) || 8));
                 const regionNoise = new Noise(seed || 1);
                 const debug_regionMap = new Uint8Array(debug_regionW * debug_regionH);
+                const countsAll = new Array<number>(buckets).fill(0);
+                const countsInMask = new Array<number>(buckets).fill(0);
                 for (let ry = 0; ry < debug_regionH; ry++) {
                     for (let rx = 0; rx < debug_regionW; rx++) {
                         const sampleX = ((rx + 0.5) / debug_regionW) * width;
@@ -265,13 +346,38 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                         const worldPt = (renderConfig && renderConfig.mode === 'isometric')
                             ? { x: screenPt.x, y: screenPt.y }
                             : isoToWorld(screenPt);
-                        const v = fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+                        const v = sampleWarpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
                         let id = Math.floor(v * buckets);
                         if (id < 0) id = 0;
                         if (id >= buckets) id = buckets - 1;
                         debug_regionMap[ry * debug_regionW + rx] = id;
+                        countsAll[id]++;
+                        if (!debugMaskData) {
+                            countsInMask[id]++;
+                        } else {
+                            const baseX = Math.max(0, Math.min(width - 1, Math.floor(sampleX)));
+                            const baseY = Math.max(0, Math.min(height - 1, Math.floor(sampleY)));
+                            const baseIndex = baseY * width + baseX;
+                            if (debugMaskData[baseIndex] !== 0) countsInMask[id]++;
+                        }
                     }
                 }
+
+                const selection = selectActiveBuckets(countsAll, countsInMask, buckets, maxActive, strategy, seed, debugMaskData);
+                let activeBuckets = selection.active;
+                if (renderConfig && Array.isArray((renderConfig as any).forceActiveBucketIds) && (renderConfig as any).forceActiveBucketIds.length > 0) {
+                    try {
+                        const forced = new Set<number>();
+                        for (const v of (renderConfig as any).forceActiveBucketIds) {
+                            const n = Number(v);
+                            if (isFinite(n) && n >= 0 && n < buckets) forced.add(Math.floor(n));
+                        }
+                        if (forced.size > 0) activeBuckets = forced;
+                    } catch (err) {
+                        // ignore malformed input
+                    }
+                }
+
                 const placeholderData = new Uint8ClampedArray(4); // 1 pixel transparent placeholder
                 placeholderData[0] = 0; placeholderData[1] = 0; placeholderData[2] = 0; placeholderData[3] = 0;
                 const out: CrackRaster = { data: placeholderData, width: 1, height: 1, quality, color: [24,24,24] };
@@ -285,7 +391,23 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                     minX,
                     minY,
                     quality,
+                    activeBuckets: Array.from(activeBuckets),
+                    countsAll: countsAll.slice(),
+                    countsInMask: countsInMask.slice(),
                 };
+                if (renderConfig) {
+                    try {
+                        const detected: Record<number, number> = {};
+                        for (let i = 0; i < countsAll.length; i++) {
+                            if (countsAll[i] > 0) detected[i] = countsAll[i];
+                        }
+                        (renderConfig as any).detectedNoiseBuckets = detected;
+                        (renderConfig as any).detectedNoiseBucketsInMask = countsInMask.slice();
+                        (renderConfig as any).activeNoiseBucketIds = Array.from(activeBuckets);
+                    } catch (err) {
+                        // ignore assignment issues
+                    }
+                }
                 return out;
             } catch (e) {
                 // fall through to returning null if debug computation fails
@@ -321,22 +443,15 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     let debug_regionCellW = 0;
     let debug_regionCellH = 0;
     let debug_buckets = 0;
-    const attachDebugRegionRequested = !!(renderConfig && renderConfig.showFbmDelimitations);
-    let debugMaskData: Uint8Array | null = null;
-    if (debugMask && debugMask.data) {
-        if (debugMask.width === width && debugMask.height === height) {
-            debugMaskData = debugMask.data;
-        } else if (typeof console !== 'undefined' && console.warn) {
-            console.warn('[crackGenerator] Ignoring debugMask due to dimension mismatch', {
-                expected: { width, height }, provided: { width: debugMask.width, height: debugMask.height }
-            });
-        }
-    }
+    const attachDebugRegionRequested = !!(renderConfig && renderConfig.showNoiseDelimitations);
     const captureCrashMaskActual = !!(captureCrashMask && debugMaskData);
     const crashMaskData = captureCrashMaskActual ? new Uint8Array(width * height) : null;
     let crashMaskCount = 0;
     let activeBuckets: Set<number> | null = null;
     let sampleBucketId: ((screenX: number, screenY: number) => number) | null = null;
+    let debug_countsAll: number[] | null = null;
+    let debug_countsInMask: number[] | null = null;
+    let debug_activeBucketList: number[] | null = null;
 
     if (renderConfig?.crackUseNoise) {
         const noiseCfg = renderConfig.crackNoiseParams || { baseScale: 1 / 480, buckets: 3, maxActiveBuckets: 2, activeBucketStrategy: 'smallest' };
@@ -365,7 +480,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 const worldPt = (renderConfig && renderConfig.mode === 'isometric')
                     ? { x: screenPt.x, y: screenPt.y }
                     : isoToWorld(screenPt);
-                const v = fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale);
+                const v = sampleWarpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale);
                 let id = Math.floor(v * buckets);
                 if (id < 0) id = 0;
                 if (id >= buckets) id = buckets - 1;
@@ -384,55 +499,8 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             }
         }
 
-        const statsAll = countsAll.map((c, i) => ({ i, c }));
-        const statsMask = countsInMask.map((c, i) => ({ i, c }));
-        const positiveMask = statsMask.filter(s => s.c > 0);
-        const positiveAll = statsAll.filter(s => s.c > 0);
-        const selectionPool = debugMaskData
-            ? (positiveMask.length > 0 ? positiveMask : (positiveAll.length > 0 ? positiveAll : statsMask))
-            : (positiveAll.length > 0 ? positiveAll : statsAll);
-        const rng = (() => {
-            let t = (seed ^ 0x9E3779B9) >>> 0;
-            return () => {
-                t = (t * 1664525 + 1013904223) >>> 0;
-                return t / 0x100000000;
-            };
-        })();
-        const pickByStrategy = (pool: { i: number; c: number }[], count: number) => {
-            if (pool.length === 0 || count <= 0) return [] as { i: number; c: number }[];
-            if (strategy === 'largest') {
-                return pool.slice().sort((a, b) => (b.c - a.c) || (a.i - b.i)).slice(0, count);
-            }
-            if (strategy === 'random') {
-                const arr = pool.slice();
-                for (let i = arr.length - 1; i > 0; i--) {
-                    const j = Math.floor(rng() * (i + 1));
-                    const tmp = arr[i];
-                    arr[i] = arr[j];
-                    arr[j] = tmp;
-                }
-                return arr.slice(0, count);
-            }
-            return pool.slice().sort((a, b) => (a.c - b.c) || (a.i - b.i)).slice(0, count);
-        };
-
-        let picked = pickByStrategy(selectionPool, maxActive);
-        if (picked.length < maxActive) {
-            const fallbackPoolBase = positiveAll.length > 0 ? positiveAll : statsAll;
-            const fallbackPool = fallbackPoolBase.filter(item => !picked.some(p => p.i === item.i));
-            const extra = pickByStrategy(fallbackPool.length > 0 ? fallbackPool : statsAll.filter(item => !picked.some(p => p.i === item.i)), maxActive - picked.length);
-            picked = picked.concat(extra);
-        }
-        if (picked.length < maxActive) {
-            for (let b = 0; picked.length < maxActive && b < buckets; b++) {
-                if (picked.some(p => p.i === b)) continue;
-                picked.push({ i: b, c: 0 });
-            }
-        }
-        activeBuckets = new Set<number>(picked.map(p => p.i));
-        if (activeBuckets.size === 0) {
-            for (let b = 0; b < buckets; b++) activeBuckets.add(b);
-        }
+        const selection = selectActiveBuckets(countsAll, countsInMask, buckets, maxActive, strategy, seed, debugMaskData);
+        activeBuckets = selection.active;
 
         // Allow callers to explicitly force which bucket ids are active by
         // providing `renderConfig.forceActiveBucketIds` (array of numbers).
@@ -457,6 +525,23 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             const ry = Math.max(0, Math.min(debug_regionH - 1, Math.floor(screenY / (debug_regionCellH || 1))));
             return debug_regionMap![ry * debug_regionW + rx];
         };
+
+        if (renderConfig) {
+            try {
+                const detected: Record<number, number> = {};
+                for (let i = 0; i < countsAll.length; i++) {
+                    if (countsAll[i] > 0) detected[i] = countsAll[i];
+                }
+                (renderConfig as any).detectedNoiseBuckets = detected;
+                (renderConfig as any).detectedNoiseBucketsInMask = countsInMask.slice();
+                (renderConfig as any).activeNoiseBucketIds = Array.from(activeBuckets!);
+            } catch (err) {
+                // ignore assignment issues
+            }
+        }
+        debug_countsAll = countsAll.slice();
+        debug_countsInMask = countsInMask.slice();
+        debug_activeBucketList = Array.from(activeBuckets!);
 
         const palette = [
             [220, 38, 38],    // vermelho
@@ -597,6 +682,9 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             minX,
             minY,
             quality,
+            activeBuckets: debug_activeBucketList || undefined,
+            countsAll: debug_countsAll || undefined,
+            countsInMask: debug_countsInMask || undefined,
         };
     }
     if (crashMaskData) {

--- a/src/tools/noiseMask.ts
+++ b/src/tools/noiseMask.ts
@@ -1,7 +1,7 @@
 import { Noise } from 'noisejs';
-import { fbmNoise as _fbmNoise } from './crackGenerator';
+import { sampleWarpedNoise } from '../lib/noiseField';
 
-export interface FbmMaskOptions {
+export interface NoiseMaskOptions {
     width: number;
     height: number;
     minX: number;
@@ -20,10 +20,10 @@ export interface FbmMaskOptions {
 }
 
 /**
- * Generate a binary (0/255) mask using the same FBM bucket strategy used by the
- * crack generator. Returns a Uint8Array of length width*height where 255 = allowed.
+ * Generate a binary (0/255) mask using the same warped-noise bucket strategy used by
+ * the crack generator. Returns a Uint8Array of length width*height where 255 = allowed.
  */
-export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
+export function generateNoiseMask(opts: NoiseMaskOptions): Uint8Array {
     const width = Math.max(1, Math.round(opts.width));
     const height = Math.max(1, Math.round(opts.height));
     const seed = (typeof opts.seed === 'number') ? (opts.seed >>> 0) : (Date.now() >>> 0);
@@ -49,7 +49,7 @@ export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
             const sampleY = ((ry + 0.5) / regionH) * height;
             const screenPt = { x: sampleX + (opts.minX || 0), y: sampleY + (opts.minY || 0) };
             const worldPt = (opts.mode === 'isometric') ? { x: screenPt.x, y: screenPt.y } : (opts.isoToWorld ? opts.isoToWorld(screenPt) : screenPt);
-            const v = _fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+            const v = sampleWarpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
             let id = Math.floor(v * buckets);
             if (id < 0) id = 0;
             if (id >= buckets) id = buckets - 1;
@@ -109,14 +109,14 @@ export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
             const noiseInst = bucketNoise[bucketId];
             const samplePt = { x: x + 0.5 + (opts.minX || 0), y: y + 0.5 + (opts.minY || 0) };
             const worldPt = (opts.mode === 'isometric') ? { x: samplePt.x, y: samplePt.y } : (opts.isoToWorld ? opts.isoToWorld(samplePt) : samplePt);
-            const baseVal = _fbmNoise(noiseInst, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+            const baseVal = sampleWarpedNoise(noiseInst, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
             const dist = Math.abs(baseVal - bucketCenters[bucketId]);
             if (dist > crackBandWidth) {
                 mask[y * width + x] = 0;
                 continue;
             }
             const edge = Math.max(0, (crackBandWidth - dist) / crackBandWidth);
-            const fine = _fbmNoise(noiseInst, worldPt.x * fineScales[bucketId] * 3.0, worldPt.y * fineScales[bucketId] * 3.0, 2, 2, 0.6);
+            const fine = sampleWarpedNoise(noiseInst, worldPt.x * fineScales[bucketId] * 3.0, worldPt.y * fineScales[bucketId] * 3.0, 2, 2, 0.6);
             const modulation = Math.max(0, Math.min(1, Math.pow(edge, 1.2) * (0.35 + 0.65 * fine)));
             const keep = modulation > 0.03; // threshold similar to alpha < 12
             mask[y * width + x] = keep ? 255 : 0;
@@ -126,7 +126,7 @@ export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
     return mask;
 }
 
-export interface FbmRegion {
+export interface NoiseRegion {
     map: Uint8Array;
     w: number;
     h: number;
@@ -137,7 +137,7 @@ export interface FbmRegion {
  * Generate the coarse bucket region map (values 0..buckets-1) without per-pixel
  * band filtering. Useful for visual debugging.
  */
-export function generateFbmRegionMap(opts: FbmMaskOptions): FbmRegion {
+export function generateNoiseRegionMap(opts: NoiseMaskOptions): NoiseRegion {
     const width = Math.max(1, Math.round(opts.width));
     const height = Math.max(1, Math.round(opts.height));
     const seed = (typeof opts.seed === 'number') ? (opts.seed >>> 0) : (Date.now() >>> 0);
@@ -158,7 +158,7 @@ export function generateFbmRegionMap(opts: FbmMaskOptions): FbmRegion {
             const sampleY = ((ry + 0.5) / regionH) * height;
             const screenPt = { x: sampleX + (opts.minX || 0), y: sampleY + (opts.minY || 0) };
             const worldPt = (opts.mode === 'isometric') ? { x: screenPt.x, y: screenPt.y } : (opts.isoToWorld ? opts.isoToWorld(screenPt) : screenPt);
-            const v = _fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+            const v = sampleWarpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
             let id = Math.floor(v * buckets);
             if (id < 0) id = 0;
             if (id >= buckets) id = buckets - 1;
@@ -172,7 +172,7 @@ export function generateFbmRegionMap(opts: FbmMaskOptions): FbmRegion {
  * Convert a coarse region map to a visual RGBA image stretched to target width/height.
  * Each bucket gets a simple color; colors are deterministic but arbitrary for debugging.
  */
-export function regionMapToRgbaImage(region: FbmRegion, targetW: number, targetH: number): Uint8ClampedArray {
+export function regionMapToRgbaImage(region: NoiseRegion, targetW: number, targetH: number): Uint8ClampedArray {
     const out = new Uint8ClampedArray(targetW * targetH * 4);
     // simple color palette (repeatable)
     const palette: [number, number, number][] = [


### PR DESCRIPTION
## Summary
- add a reusable helper in the crack generator to pick active warped-noise buckets and expose their stats in the debug metadata
- capture the bucket stats in renderConfig for UI controls and include them when returning the crack raster
- render the warped-noise region overlay inside the crack container when "show noise delimitations" is enabled

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc88e1decc832a933363c833157d26