### PR TITLE
Refine crack noise delimitation mask

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -239,10 +239,14 @@ const App: React.FC = () => {
     const activeBucketsForDisplay = Math.max(1, Math.min(bucketsForDisplay, Math.round(1 + crackAreaCoverage * (bucketsForDisplay - 1))));
     const coveragePercent = Math.round((activeBucketsForDisplay / bucketsForDisplay) * 100);
     const coverageLabel = coveragePercent <= 33 ? 'Baixa' : (coveragePercent >= 67 ? 'Alta' : 'Média');
-    const baseBandDisplay = noiseDefaults.crackBandWidth || 0.008;
-    const minBandDisplay = Math.max(0.001, baseBandDisplay * 0.5);
-    const maxBandDisplay = Math.min(0.05, baseBandDisplay * 2.5);
-    const displayBandWidth = minBandDisplay + (maxBandDisplay - minBandDisplay) * crackAreaCoverage;
+    const baseBandDisplay = noiseDefaults.crackBandWidth || 0.012;
+    const minBandDisplay = Math.max(0.0005, baseBandDisplay * 0.35);
+    const maxBandDisplay = Math.min(0.2, baseBandDisplay * 12);
+    const coverageForBand = Math.pow(Math.min(1, Math.max(0, crackAreaCoverage)), 0.85);
+    const displayBandWidth = minBandDisplay + (maxBandDisplay - minBandDisplay) * coverageForBand;
+    const displayBandWidthLabel = displayBandWidth >= 0.1
+        ? displayBandWidth.toFixed(2)
+        : displayBandWidth.toFixed(3);
     const [edgeScale, setEdgeScale] = useState<number>(() => safeLoadNumber('edgeScale', (config as any).render.edgeTextureScale || 1.0));
     const [edgeAlpha, setEdgeAlpha] = useState<number>(() => safeLoadNumber('edgeAlpha', (config as any).render.edgeTextureAlpha ?? 1.0));
     // controls for road lane overlay
@@ -359,10 +363,11 @@ const App: React.FC = () => {
         const buckets = Math.max(1, defaults.buckets || params.buckets || 3);
         const coverage = Math.min(1, Math.max(0, crackAreaCoverage));
         const activeCount = Math.max(1, Math.min(buckets, Math.round(1 + coverage * (buckets - 1))));
-        const baseBand = defaults.crackBandWidth || 0.008;
-        const minBand = Math.max(0.001, baseBand * 0.5);
-        const maxBand = Math.min(0.05, baseBand * 2.5);
-        const computedBand = minBand + (maxBand - minBand) * coverage;
+        const baseBand = defaults.crackBandWidth || 0.012;
+        const minBand = Math.max(0.0005, baseBand * 0.35);
+        const maxBand = Math.min(0.2, baseBand * 12);
+        const coverageForBand = Math.pow(Math.min(1, Math.max(0, coverage)), 0.85);
+        const computedBand = minBand + (maxBand - minBand) * coverageForBand;
         const nextParams = {
             ...params,
             baseScale: defaults.baseScale,
@@ -787,7 +792,7 @@ const App: React.FC = () => {
                 <div style={{ display: 'inline-block', marginLeft: 12, padding: '6px', border: '1px solid #444', borderRadius: 6 }}>
                     <div style={{ fontSize: 12, fontWeight: 700, marginBottom: 6 }}>Crack Noise</div>
                     <label style={{ fontSize: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <input type="checkbox" checked={crackUseNoise} onChange={(e) => setCrackUseNoise(e.target.checked)} /> Usar fBm para delimitar
+                        <input type="checkbox" checked={crackUseNoise} onChange={(e) => setCrackUseNoise(e.target.checked)} /> Usar ruído distorcido para delimitar
                     </label>
                     <label style={{ fontSize: 12, display: 'flex', alignItems: 'center', gap: 8, marginTop: 6 }}>
                         <input type="checkbox" checked={crashMaskEnabled} onChange={(e) => setCrashMaskEnabled(e.target.checked)} /> Aplicar Crash Mask (apenas nas vias)
@@ -812,7 +817,7 @@ const App: React.FC = () => {
                             <span style={{ fontSize: 11, opacity: 0.7 }}>Mais</span>
                         </div>
                         <div style={{ fontSize: 11, opacity: 0.8 }}>
-                            Cobertura {coverageLabel} ({coveragePercent}%) · {activeBucketsForDisplay}/{bucketsForDisplay} regiões ativas · faixa ≈ {displayBandWidth.toFixed(3)}
+                            Cobertura {coverageLabel} ({coveragePercent}%) · {activeBucketsForDisplay}/{bucketsForDisplay} regiões ativas · faixa ≈ {displayBandWidthLabel}
                         </div>
                         <div style={{ fontSize: 10, opacity: 0.6 }}>
                             Ajuste o controle e pressione Regenerate para recalcular as rachaduras.
@@ -850,11 +855,11 @@ const App: React.FC = () => {
                     <input type="checkbox" checked={Boolean((config as any).render?.debugCrackMask)} onChange={(e) => { (config as any).render = { ...(config as any).render, debugCrackMask: e.target.checked }; setUiTick(t => t + 1); }} /> Show crack mask debug
                 </label>
                 <label style={{ marginLeft: 8, display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-                    <input type="checkbox" checked={Boolean((config as any).render?.showFbmDelimitations)} onChange={(e) => { (config as any).render = { ...(config as any).render, showFbmDelimitations: e.target.checked }; try { localStorage.setItem('showFbmDelimitations', String(e.target.checked)); } catch (e) {} setUiTick(t => t + 1); }} /> Show FBM delimitations
+                    <input type="checkbox" checked={Boolean((config as any).render?.showNoiseDelimitations)} onChange={(e) => { (config as any).render = { ...(config as any).render, showNoiseDelimitations: e.target.checked }; try { localStorage.setItem('showNoiseDelimitations', String(e.target.checked)); } catch (e) {} setUiTick(t => t + 1); }} /> Show noise delimitations
                 </label>
-                {/* Small UI panel showing detected FBM buckets and manual overrides */}
+                {/* Small UI panel showing detected noise buckets and manual overrides */}
                 <div style={{ marginLeft: 8, display: 'inline-flex', alignItems: 'center', gap: 8 }}>
-                    {/* Legend for FBM bucket states */}
+                    {/* Legend for noise bucket states */}
                     <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8, background: 'rgba(0,0,0,0.2)', padding: '6px 8px', borderRadius: 6 }}>
                         <div style={{ display: 'inline-flex', flexDirection: 'column', gap: 4, alignItems: 'flex-start' }}>
                             <div style={{ fontSize: 11, color: '#EEE', fontWeight: 700 }}>Legenda</div>
@@ -879,13 +884,13 @@ const App: React.FC = () => {
                     </div>
                     {(() => {
                         try {
-                            const detected: Record<number, number> | undefined = (config as any).render?.detectedFbmBuckets;
+                            const detected: Record<number, number> | undefined = (config as any).render?.detectedNoiseBuckets;
                             const forced: number[] | undefined = (config as any).render?.forceActiveBucketIds;
                             if (!detected) return null;
                             const ids = Object.keys(detected).map(k => parseInt(k, 10)).filter(n => !isNaN(n)).sort((a,b)=>a-b);
                             return (
                                 <div style={{ display: 'inline-flex', gap: 6, alignItems: 'center', background: 'rgba(0,0,0,0.45)', padding: '6px 8px', borderRadius: 6 }}>
-                                    <div style={{ fontSize: 12, fontWeight: 700, color: '#EEE', marginRight: 6 }}>FBM Buckets</div>
+                                    <div style={{ fontSize: 12, fontWeight: 700, color: '#EEE', marginRight: 6 }}>Noise Buckets</div>
                                     {ids.map(id => {
                                         const count = detected[id] || 0;
                                         const active = Array.isArray(forced) ? forced.indexOf(id) >= 0 : false;

--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -73,6 +73,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
     const roadCrackTextureRef = useRef<PIXI.Texture | null>(roadCrackTexture || null);
     const edgeTextureRef = useRef<PIXI.Texture | null>(edgeTexture || null);
     const proceduralCrackGraphicsRef = useRef<PIXI.Graphics | null>(null);
+    const crackNoiseDebugRef = useRef<PIXI.Graphics | null>(null);
     // Cache para evitar reconstruções pesadas dos marcadores/mascara quando nada mudou
     const laneMarkerCacheRef = useRef<{ key: string; container: PIXI.Container | null } | null>(null);
     const roadLaneScaleRef = useRef<number | undefined>(roadLaneScale);
@@ -219,19 +220,35 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
         let drew = false;
         for (let y = 0; y < maskHeight; y++) {
             let runStart = -1;
+            let runSum = 0;
+            let runCount = 0;
             for (let x = 0; x <= maskWidth; x++) {
-                const val = x < maskWidth ? mask[y * maskWidth + x] : 0;
-                if (val > 0) {
-                    if (runStart === -1) runStart = x;
+                const sample = x < maskWidth ? mask[y * maskWidth + x] : 0;
+                const weight = Math.max(0, Math.min(1, sample / 255));
+                if (weight > 0) {
+                    if (runStart === -1) {
+                        runStart = x;
+                        runSum = weight;
+                        runCount = 1;
+                    } else {
+                        runSum += weight;
+                        runCount++;
+                    }
                 } else if (runStart !== -1) {
                     const runLen = x - runStart;
                     if (runLen > 0) {
-                        g.beginFill(color, finalAlpha);
-                        g.drawRect(runStart * stepX, y * stepY, runLen * stepX, stepY);
-                        g.endFill();
-                        drew = true;
+                        const avgWeight = runSum / (runCount || 1);
+                        const drawAlpha = Math.max(0, Math.min(1, avgWeight * finalAlpha));
+                        if (drawAlpha > 0.01) {
+                            g.beginFill(color, drawAlpha);
+                            g.drawRect(runStart * stepX, y * stepY, runLen * stepX, stepY);
+                            g.endFill();
+                            drew = true;
+                        }
                     }
                     runStart = -1;
+                    runSum = 0;
+                    runCount = 0;
                 }
             }
         }
@@ -2077,6 +2094,10 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                 try { proceduralCrackGraphicsRef.current.destroy(true); } catch (e) {}
                 proceduralCrackGraphicsRef.current = null;
             }
+            if (crackNoiseDebugRef.current) {
+                try { crackNoiseDebugRef.current.destroy(true); } catch (e) {}
+                crackNoiseDebugRef.current = null;
+            }
             roadCrackDisplayRef.current = null;
             const renderCfg = (config as any).render || {};
             const useProceduralCracks = !!renderCfg.crackUseProcedural;
@@ -2147,6 +2168,8 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                     const spriteH = Math.max(4, Math.ceil(maxY - minY));
                     let cracksDisplay: PIXI.DisplayObject | null = null;
                     let crashMaskDebugGraphics: PIXI.Graphics | null = null;
+                    let noiseDebugGraphics: PIXI.Graphics | null = null;
+                    let noiseMaskGraphics: PIXI.Graphics | null = null;
                     const crashMaskActive = !!(renderCfg.crashMaskEnabled);
                     const wantCrashMaskDebug = !!(renderCfg.debugCrackMask);
                     const shouldBuildCrashMask = (crashMaskActive || wantCrashMaskDebug) && polys.length > 0;
@@ -2171,6 +2194,73 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                             captureCrashMask: crashMaskActive || wantCrashMaskDebug,
                         });
                         if (raster) {
+                        let hasActiveHighlight = false;
+                        if (renderCfg.showNoiseDelimitations && raster.debugRegion) {
+                            try {
+                                const region = raster.debugRegion;
+                                const palette = [
+                                    0xdc2626,
+                                    0x22c55e,
+                                    0x2563eb,
+                                    0xeab308,
+                                    0xa855f7,
+                                    0x10b981,
+                                    0xfbbf24,
+                                    0xf43f5e,
+                                ];
+                                const highlight = new Set<number>();
+                                if (Array.isArray(region.activeBucketIds)) {
+                                    for (const v of region.activeBucketIds) {
+                                        const n = Number(v);
+                                        if (Number.isFinite(n)) highlight.add(Math.floor(n));
+                                    }
+                                }
+                                const hasHighlight = highlight.size > 0;
+                                hasActiveHighlight = hasHighlight;
+                                const safeCellW = Math.max(0.0001, Number.isFinite(region.cellW) ? region.cellW : 0);
+                                const safeCellH = Math.max(0.0001, Number.isFinite(region.cellH) ? region.cellH : 0);
+                                const strokeWidth = Math.max(
+                                    0.35,
+                                    Math.min(2.25, Math.min(safeCellW, safeCellH) * 0.08),
+                                );
+                                const baseFillAlpha = hasHighlight ? 0.12 : 0.22;
+                                const activeFillAlpha = 0.36;
+                                const g = new PIXI.Graphics();
+                                for (let ry = 0; ry < region.h; ry++) {
+                                    for (let rx = 0; rx < region.w; rx++) {
+                                        const idx = ry * region.w + rx;
+                                        const bucket = region.map[idx] ?? 0;
+                                        const color = palette[bucket % palette.length] ?? 0xffffff;
+                                        const isActive = !hasHighlight || highlight.has(bucket);
+                                        const strokeAlpha = isActive ? 0.75 : 0.35;
+                                        const fillAlpha = isActive ? activeFillAlpha : baseFillAlpha;
+                                        g.lineStyle(strokeWidth, color, strokeAlpha);
+                                        g.beginFill(color, fillAlpha);
+                                        g.drawRect(rx * safeCellW, ry * safeCellH, safeCellW, safeCellH);
+                                        g.endFill();
+                                    }
+                                }
+                                noiseDebugGraphics = g;
+                            } catch (err) {
+                                try { console.warn('[GameCanvas] Failed to build noise delimitations overlay', err); } catch (e) {}
+                            }
+                        }
+                        if (renderCfg.showNoiseDelimitations && raster.noiseMask) {
+                            try {
+                                const overlayAlpha = hasActiveHighlight ? 0.34 : 0.28;
+                                noiseMaskGraphics = maskToGraphics(
+                                    raster.noiseMask.data,
+                                    raster.noiseMask.width,
+                                    raster.noiseMask.height,
+                                    spriteW,
+                                    spriteH,
+                                    0x38bdf8,
+                                    overlayAlpha,
+                                );
+                            } catch (err) {
+                                try { console.warn('[GameCanvas] Failed to build noise mask overlay', err); } catch (e) {}
+                            }
+                        }
                             const alphaMultiplier = (typeof roadCrackAlpha === 'number' && isFinite(roadCrackAlpha)) ? roadCrackAlpha : 1;
                             const graphics = rasterToGraphics(raster, spriteW, spriteH, alphaMultiplier);
                             if (graphics) {
@@ -2237,13 +2327,26 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                         cracksDisplay = sprite;
                     }
 
-                    if (cracksDisplay) {
+                    if (cracksDisplay || noiseDebugGraphics || noiseMaskGraphics) {
                         const container = new PIXI.Container();
                         container.x = minX;
                         container.y = minY;
-                        cracksDisplay.x = 0;
-                        cracksDisplay.y = 0;
-                        container.addChild(cracksDisplay);
+                        if (noiseMaskGraphics) {
+                            noiseMaskGraphics.x = 0;
+                            noiseMaskGraphics.y = 0;
+                            container.addChild(noiseMaskGraphics);
+                        }
+                        if (noiseDebugGraphics) {
+                            noiseDebugGraphics.x = 0;
+                            noiseDebugGraphics.y = 0;
+                            container.addChild(noiseDebugGraphics);
+                            crackNoiseDebugRef.current = noiseDebugGraphics;
+                        }
+                        if (cracksDisplay) {
+                            cracksDisplay.x = 0;
+                            cracksDisplay.y = 0;
+                            container.addChild(cracksDisplay);
+                        }
                         if (crashMaskDebugGraphics) {
                             container.addChild(crashMaskDebugGraphics);
                         }

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -285,12 +285,12 @@ export const config = {
     intersectionPatchAlwaysVisibleWithOutlines: true,
     // Mostrar contornos dos quarteirões
     showBlockOutlines: true,
-    // Toggle procedural crash mask (intersection of FBM buckets & road polygons)
+    // Toggle procedural crash mask (intersection of warped-noise buckets & road polygons)
     crashMaskEnabled: false,
     // Crack mask debug/padding controls (UI-adjustable)
     debugCrackMask: false,
-    // Show FBM delimitations (separate toggle for fBm regions / buckets)
-    showFbmDelimitations: false,
+    // Show warped-noise delimitations (separate toggle for noise regions / buckets)
+    showNoiseDelimitations: false,
     // Default padding (px) used for crack mask bounding boxes
     crackMaskPaddingDefault: 4,
     // Extra padding (px) applied when heuristic triggers — fallback default 8
@@ -305,13 +305,13 @@ export const config = {
         dilateRadius: 2,
         quality: 2,
     },
-    // Use Perlin/Fbm noise to distribute cracks instead of masking full roads
+    // Use warped noise to distribute cracks instead of masking full roads
     crackUseNoise: true,
-    // Parâmetros para geração procedural de rachaduras via fBm/Perlin.
+    // Parâmetros para geração procedural de rachaduras via campo de ruído distorcido.
     // - baseScale: frequência base do ruído (1/meters). Valores maiores => manchas maiores.
-    // - octaves/lacunarity/gain: parâmetros de fBm.
+    // - octaves/lacunarity/gain: controlam intensidade e detalhamento da distorção.
     // - buckets: número de regiões quantizadas no mapa de ruído.
-    // - crackBandWidth: largura da faixa em torno do centro do bucket que gera rachaduras (0.002..0.1)
+    // - crackBandWidth: largura da faixa em torno do centro do bucket que gera rachaduras (0.002..0.2)
     // - maxActiveBuckets: quantos buckets são efetivamente usados para desenhar rachaduras
     crackNoiseParams: {
         baseScale: 1 / 480,
@@ -319,7 +319,7 @@ export const config = {
         lacunarity: 2.0,
         gain: 0.5,
         buckets: 3,
-        crackBandWidth: 0.008,
+        crackBandWidth: 0.012,
         maxActiveBuckets: 2,
         // Escolha de quais buckets são ativados: 'smallest' (regiões menores), 'largest', 'random'
         activeBucketStrategy: 'smallest'

--- a/src/game_modules/mapgen.ts
+++ b/src/game_modules/mapgen.ts
@@ -216,7 +216,7 @@ let noise: Noise;
 export type ZoneName = 'downtown' | 'residential' | 'commercial' | 'industrial' | 'rural';
 
 export function getZoneAt(p: Point | { x: number; y: number }): ZoneName {
-    // Zonas puramente por Perlin/fBm (independente das ruas)
+    // Zonas puramente por ruído distorcido (independente das ruas)
     return Zoning.zoneAt(p);
 }
 
@@ -637,7 +637,7 @@ export function generate(seed: string | number): MapGenerationResult {
     // Seeded noise instance for deterministic generation
     const noiseSeed = Math.floor(Math.random() * 65536);
     noise = new Noise(noiseSeed);
-    // Inicializar Zoning com perlin fBm antes da criação das ruas
+    // Inicializar Zoning com o novo campo de ruído distorcido antes da criação das ruas
     Zoning.init(noiseSeed);
     // alinhar heatmap próximo da origem (centro inicial da cidade)
     heatmap.calibrateTo({ x: 0, y: 0 });

--- a/src/game_modules/zoning.ts
+++ b/src/game_modules/zoning.ts
@@ -3,6 +3,7 @@ import type { Point } from '../generic_modules/math';
 import type { ZoneName } from './mapgen';
 import { heatmap } from './mapgen';
 import { config } from './config';
+import { sampleWarpedNoise } from '../lib/noiseField';
 
 export type ZoningParams = {
   baseScale: number;
@@ -11,17 +12,6 @@ export type ZoningParams = {
   gain: number;
   thresholds: { r1: number; r2: number; r3: number; r4: number };
 };
-
-function fbm(noise: Noise, x: number, y: number, octaves = 4, lacunarity = 2, gain = 0.5): number {
-  let freq = 1, amp = 1, sum = 0, norm = 0;
-  for (let i = 0; i < octaves; i++) {
-    sum += noise.perlin2(x * freq, y * freq) * amp;
-    norm += amp;
-    freq *= lacunarity;
-    amp *= gain;
-  }
-  return (sum / (norm || 1)) * 0.5 + 0.5;
-}
 
 const Zoning = new (class {
   private _noise: Noise | null = null;
@@ -97,7 +87,7 @@ const Zoning = new (class {
   private _macroNoise(x: number, y: number): number {
     const mn = config.zoningModel.macroNoise;
     if (!this._noise) return 0;
-    return fbm(this._noise, x * mn.baseScale, y * mn.baseScale, mn.octaves, mn.lacunarity, mn.gain) * 2 - 1; // [-1,1]
+    return sampleWarpedNoise(this._noise, x * mn.baseScale, y * mn.baseScale, mn.octaves, mn.lacunarity, mn.gain) * 2 - 1; // [-1,1]
   }
 
   private _scoreProcedural(p: Point): Record<ZoneName, number> {
@@ -153,7 +143,7 @@ const Zoning = new (class {
       else z = 'rural';
   } else if (config.zoningModel.mode === 'perlin') {
       const { baseScale, octaves, lacunarity, gain, thresholds } = this._params;
-      const n = fbm(this._noise, p.x * baseScale, p.y * baseScale, octaves, lacunarity, gain);
+      const n = sampleWarpedNoise(this._noise, p.x * baseScale, p.y * baseScale, octaves, lacunarity, gain);
       if (n < thresholds.r1) z = 'rural';
       else if (n < thresholds.r2) z = 'residential';
       else if (n < thresholds.r3) z = 'commercial';

--- a/src/lib/noiseField.ts
+++ b/src/lib/noiseField.ts
@@ -1,0 +1,81 @@
+import { Noise } from 'noisejs';
+
+export interface WarpedNoiseOptions {
+    /** Strength multiplier applied to the domain warp displacements. */
+    warpStrength?: number;
+    /** Base frequency used by the warp noise fields. */
+    warpScale?: number;
+    /** Number of warp layers applied before sampling the base noise. */
+    warpOctaves?: number;
+    /** Frequency multiplier between warp layers. */
+    warpLacunarity?: number;
+    /** Amplitude multiplier between warp layers. */
+    warpGain?: number;
+    /** Additional layers of detail when sampling the base pattern. */
+    baseLayers?: number;
+    /** Frequency multiplier for base layers. */
+    baseLacunarity?: number;
+    /** Amplitude multiplier for base layers. */
+    baseGain?: number;
+}
+
+const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+
+/**
+ * Sample a 2D noise field using domain-warped Perlin + Simplex noise.
+ *
+ * The goal is to produce organic looking regions without relying on the
+ * traditional layered accumulation that was previously used throughout the
+ * project. Domain warping adds large-scale drifts, while a handful of
+ * base layers provide localized variation.
+ */
+export function sampleWarpedNoise(
+    noise: Noise,
+    x: number,
+    y: number,
+    octaves = 3,
+    lacunarity = 2,
+    gain = 0.5,
+    options: WarpedNoiseOptions = {},
+): number {
+    const warpOctaves = Math.max(1, Math.floor(options.warpOctaves ?? octaves));
+    const warpScale = options.warpScale ?? 0.75;
+    const warpStrengthBase = options.warpStrength ?? 0.65;
+    const warpLacunarity = options.warpLacunarity ?? lacunarity;
+    const warpGain = options.warpGain ?? gain;
+
+    let warpedX = x;
+    let warpedY = y;
+    let warpStrength = warpStrengthBase;
+    let freq = 1;
+    for (let i = 0; i < warpOctaves; i++) {
+        const dx = noise.simplex2((x + 17.13) * warpScale * freq, (y - 41.97) * warpScale * freq);
+        const dy = noise.simplex2((x - 93.11) * warpScale * freq, (y + 26.41) * warpScale * freq);
+        warpedX += dx * warpStrength;
+        warpedY += dy * warpStrength;
+        freq *= warpLacunarity;
+        warpStrength *= warpGain;
+    }
+
+    const baseLayers = Math.max(1, Math.floor(options.baseLayers ?? 2));
+    const baseLacunarity = options.baseLacunarity ?? (lacunarity * 0.85);
+    const baseGain = options.baseGain ?? (gain * 0.9);
+
+    let layerFreq = 1;
+    let layerAmp = 1;
+    let accum = 0;
+    let weight = 0;
+    for (let i = 0; i < baseLayers; i++) {
+        const perlin = noise.perlin2(warpedX * layerFreq, warpedY * layerFreq);
+        const simplex = noise.simplex2((warpedX + 12.7) * layerFreq, (warpedY - 3.8) * layerFreq);
+        const ridge = 1 - Math.abs(perlin);
+        const combined = (perlin * 0.5 + simplex * 0.35 + (ridge * 2 - 1) * 0.15);
+        accum += combined * layerAmp;
+        weight += layerAmp;
+        layerFreq *= baseLacunarity;
+        layerAmp *= baseGain;
+    }
+
+    const normalized = (weight > 0 ? accum / weight : accum) * 0.5 + 0.5;
+    return clamp01(normalized);
+}

--- a/src/overlays/NoiseZoning.ts
+++ b/src/overlays/NoiseZoning.ts
@@ -1,6 +1,6 @@
 /*
  * NoiseZoning Overlay
- * Perlin/fBm-only zoning overlay for city generator
+ * Warped-noise zoning overlay for city generator
  * API: attach(canvas), toggle(), reseed(), redraw()
  * Independent of roads/buildings
  */
@@ -8,22 +8,7 @@ import { ZoneName } from '../game_modules/mapgen';
 import { config } from '../game_modules/config';
 import Zoning from '../game_modules/zoning';
 import { Noise } from 'noisejs';
-
-// Simple Perlin noise implementation (can be replaced by external lib)
-function fbm(noise: Noise, x: number, y: number, octaves = 4, lacunarity = 2, gain = 0.5): number {
-  let freq = 1;
-  let amp = 1;
-  let sum = 0;
-  let norm = 0;
-  for (let i = 0; i < octaves; i++) {
-    sum += noise.perlin2(x * freq, y * freq) * amp;
-    norm += amp;
-    freq *= lacunarity;
-    amp *= gain;
-  }
-  // Map from [-norm, norm] to [0,1]
-  return (sum / (norm || 1)) * 0.5 + 0.5;
-}
+import { sampleWarpedNoise } from '../lib/noiseField';
 
 
 export type NoiseZoningAPI = {
@@ -172,7 +157,7 @@ const NoiseZoning: InternalNoiseZoning = {
         // Mapear pixel -> coordenadas de cena, seguindo pan/zoom
         const Sx = cameraX + (x - cx) / zoom;
         const Sy = cameraY + (y - cy) / zoom;
-        const n = fbm(this._noise, Sx * baseScale, Sy * baseScale, octaves, lacunarity, gain);
+        const n = sampleWarpedNoise(this._noise, Sx * baseScale, Sy * baseScale, octaves, lacunarity, gain);
         let zone: ZoneName = 'residential';
         if (n < thresholds.r1) zone = 'rural';
         else if (n < thresholds.r2) zone = 'residential';

--- a/src/tools/crackGenerator.ts
+++ b/src/tools/crackGenerator.ts
@@ -1,4 +1,5 @@
 import { Noise } from 'noisejs';
+import { sampleWarpedNoise } from '../lib/noiseField';
 
 export interface CrackGeneratorOptions {
     divisions: number;
@@ -16,18 +17,6 @@ function makeRng(seed: number) {
         return state / 0x100000000;
     };
 }
-
-export const fbmNoise = (
-    noise: Noise,
-    x: number,
-    y: number,
-    _octaves = 1,
-    _lacunarity = 2,
-    _gain = 0.5,
-) => {
-    const value = noise.perlin2(x, y);
-    return value * 0.5 + 0.5;
-};
 
 export function generateVoronoiCrackImage(width: number, height: number, options: CrackGeneratorOptions): Uint8ClampedArray {
     const sw = Math.max(1, Math.round(width));
@@ -160,7 +149,7 @@ export interface CrackRaster {
     height: number;
     quality: number;
     color: [number, number, number];
-    // Optional debug info for noise bucket region visualization (legacy FBM naming)
+    // Optional debug info for noise bucket region visualization (legacy naming kept for backwards compatibility)
     debugRegion?: {
         map: Uint8Array;
         w: number;
@@ -171,6 +160,12 @@ export interface CrackRaster {
         minX: number;
         minY: number;
         quality: number;
+        activeBucketIds?: number[];
+    };
+    noiseMask?: {
+        data: Uint8Array;
+        width: number;
+        height: number;
     };
     crashMask?: {
         data: Uint8Array;
@@ -240,14 +235,14 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
         if (typeof console !== 'undefined' && console.warn) {
             console.warn('[crackGenerator] Procedural crack raster skipped – area too large after clamping', { canvasW, canvasH, quality });
         }
-        // If the caller explicitly requested legacy FBM debug delimitations, return a
+        // If the caller explicitly requested legacy noise debug delimitations, return a
         // tiny placeholder raster that includes a coarse `debugRegion` so the
         // UI can still visualize noise buckets even when the full raster is
         // skipped due to clamping limits.
-    if (renderConfig?.showFbmDelimitations && renderConfig?.crackUseNoise) {
+    if (renderConfig?.showNoiseDelimitations && renderConfig?.crackUseNoise) {
             try {
                 const seed = Math.floor((renderConfig?.crackSeed ?? Date.now())) >>> 0;
-                const noiseCfg = renderConfig.crackNoiseParams || { baseScale: 1 / 480, octaves: 4, lacunarity: 2, gain: 0.5, buckets: 3 };
+                const noiseCfg = renderConfig.crackNoiseParams || { baseScale: 1 / 480, octaves: 4, lacunarity: 2, gain: 0.5, buckets: 3, crackBandWidth: 0.012 };
                 const baseScale = noiseCfg.baseScale || 1 / 480;
                 const octaves = noiseCfg.octaves || 4;
                 const lacunarity = noiseCfg.lacunarity || 2;
@@ -265,7 +260,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                         const worldPt = (renderConfig && renderConfig.mode === 'isometric')
                             ? { x: screenPt.x, y: screenPt.y }
                             : isoToWorld(screenPt);
-                        const v = fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+                        const v = sampleWarpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
                         let id = Math.floor(v * buckets);
                         if (id < 0) id = 0;
                         if (id >= buckets) id = buckets - 1;
@@ -321,7 +316,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     let debug_regionCellW = 0;
     let debug_regionCellH = 0;
     let debug_buckets = 0;
-    const attachDebugRegionRequested = !!(renderConfig && renderConfig.showFbmDelimitations);
+    const attachDebugRegionRequested = !!(renderConfig && renderConfig.showNoiseDelimitations);
     let debugMaskData: Uint8Array | null = null;
     if (debugMask && debugMask.data) {
         if (debugMask.width === width && debugMask.height === height) {
@@ -337,10 +332,25 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
     let crashMaskCount = 0;
     let activeBuckets: Set<number> | null = null;
     let sampleBucketId: ((screenX: number, screenY: number) => number) | null = null;
+    let noiseMaskData: Uint8Array | null = null;
+    let noiseMaskHits = 0;
 
     if (renderConfig?.crackUseNoise) {
-        const noiseCfg = renderConfig.crackNoiseParams || { baseScale: 1 / 480, buckets: 3, maxActiveBuckets: 2, activeBucketStrategy: 'smallest' };
+        const noiseCfg = renderConfig.crackNoiseParams || {
+            baseScale: 1 / 480,
+            buckets: 3,
+            maxActiveBuckets: 2,
+            activeBucketStrategy: 'smallest',
+            crackBandWidth: 0.012,
+            octaves: 4,
+            lacunarity: 2,
+            gain: 0.5,
+        };
         const baseScale = noiseCfg.baseScale || 1 / 480;
+        const octaves = Math.max(1, noiseCfg.octaves || 4);
+        const lacunarity = noiseCfg.lacunarity || 2;
+        const gain = noiseCfg.gain || 0.5;
+        const crackBandWidth = Math.max(0.0005, Math.min(0.25, noiseCfg.crackBandWidth || 0.012));
         const buckets = Math.max(1, Math.min(8, noiseCfg.buckets || 3));
         const maxActive = Math.max(1, Math.min(buckets, noiseCfg.maxActiveBuckets || 2));
         const strategy = noiseCfg.activeBucketStrategy || 'smallest';
@@ -365,7 +375,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 const worldPt = (renderConfig && renderConfig.mode === 'isometric')
                     ? { x: screenPt.x, y: screenPt.y }
                     : isoToWorld(screenPt);
-                const v = fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale);
+                const v = sampleWarpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
                 let id = Math.floor(v * buckets);
                 if (id < 0) id = 0;
                 if (id >= buckets) id = buckets - 1;
@@ -457,17 +467,65 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             const ry = Math.max(0, Math.min(debug_regionH - 1, Math.floor(screenY / (debug_regionCellH || 1))));
             return debug_regionMap![ry * debug_regionW + rx];
         };
+        const bucketNoise: Noise[] = new Array(buckets);
+        const bucketCenters: number[] = new Array(buckets);
+        const fineScales: number[] = new Array(buckets);
+        for (let b = 0; b < buckets; b++) {
+            bucketNoise[b] = new Noise((seed + b * 97 + 13) >>> 0);
+            bucketCenters[b] = (b + 0.5) / buckets;
+            fineScales[b] = baseScale * (1.5 + b * 0.6);
+        }
+        noiseMaskData = new Uint8Array(width * height);
+        noiseMaskHits = 0;
+        const computeWorldPoint = (screenX: number, screenY: number) => {
+            const screenPt = { x: screenX + minX, y: screenY + minY };
+            return (renderConfig && renderConfig.mode === 'isometric') ? screenPt : isoToWorld(screenPt);
+        };
+        for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+                const baseIndex = y * width + x;
+                if (debugMaskData && debugMaskData[baseIndex] === 0) {
+                    noiseMaskData[baseIndex] = 0;
+                    continue;
+                }
+                const bucketId = sampleBucketId!(x + 0.5, y + 0.5);
+                if (!activeBuckets!.has(bucketId)) {
+                    noiseMaskData[baseIndex] = 0;
+                    continue;
+                }
+                const worldPt = computeWorldPoint(x + 0.5, y + 0.5);
+                const noiseInst = bucketNoise[bucketId];
+                const baseVal = sampleWarpedNoise(noiseInst, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+                const center = bucketCenters[bucketId];
+                const dist = Math.abs(baseVal - center);
+                if (dist > crackBandWidth) {
+                    noiseMaskData[baseIndex] = 0;
+                    continue;
+                }
+                const edge = Math.max(0, (crackBandWidth - dist) / crackBandWidth);
+                const fine = sampleWarpedNoise(
+                    noiseInst,
+                    worldPt.x * fineScales[bucketId] * 3.0,
+                    worldPt.y * fineScales[bucketId] * 3.0,
+                    2,
+                    2,
+                    0.6,
+                );
+                const modulation = Math.max(0, Math.min(1, Math.pow(edge, 1.15) * (0.45 + 0.55 * fine)));
+                if (modulation <= 0.02) {
+                    noiseMaskData[baseIndex] = 0;
+                    continue;
+                }
+                const stored = Math.max(0, Math.min(255, Math.round(modulation * 255)));
+                noiseMaskData[baseIndex] = stored;
+                noiseMaskHits++;
+            }
+        }
+        if (noiseMaskHits === 0) {
+            noiseMaskData = null;
+        }
 
-        const palette = [
-            [220, 38, 38],    // vermelho
-            [34, 197, 94],    // verde
-            [37, 99, 235],    // azul
-            [234, 179, 8],    // amarelo
-            [168, 85, 247],   // roxo
-            [16, 185, 129],   // teal
-            [251, 191, 36],   // laranja
-            [244, 63, 94],    // rosa
-        ];
+        const crackColor: [number, number, number] = [24, 24, 24];
         let hasCoverage = false;
         for (let y = 0; y < canvasH; y++) {
             for (let x = 0; x < canvasW; x++) {
@@ -483,15 +541,27 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                     data[idx + 3] = 0;
                     continue;
                 }
+                if (noiseMaskData && noiseMaskData[baseIndex] === 0) {
+                    data[idx + 3] = 0;
+                    continue;
+                }
                 const bucketId = sampleBucketId!(screenX, screenY);
                 if (!activeBuckets!.has(bucketId)) {
                     data[idx + 3] = 0;
                     continue;
                 }
-                const color = palette[bucketId % palette.length];
-                data[idx] = color[0];
-                data[idx + 1] = color[1];
-                data[idx + 2] = color[2];
+                if (noiseMaskData) {
+                    const maskAlpha = Math.max(0, Math.min(1, noiseMaskData[baseIndex] / 255));
+                    const finalAlpha = Math.max(0, Math.min(255, Math.round(alpha * maskAlpha)));
+                    if (finalAlpha <= 0) {
+                        data[idx + 3] = 0;
+                        continue;
+                    }
+                    data[idx + 3] = finalAlpha;
+                }
+                data[idx] = crackColor[0];
+                data[idx + 1] = crackColor[1];
+                data[idx + 2] = crackColor[2];
                 hasCoverage = true;
             }
         }
@@ -500,6 +570,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 for (let x = 0; x < width; x++) {
                     const baseIndex = y * width + x;
                     if (debugMaskData && debugMaskData[baseIndex] === 0) continue;
+                    if (noiseMaskData && noiseMaskData[baseIndex] === 0) continue;
                     const bucketId = sampleBucketId!(x + 0.5, y + 0.5);
                     if (activeBuckets!.has(bucketId) && crashMaskData[baseIndex] === 0) {
                         crashMaskData[baseIndex] = 255;
@@ -508,9 +579,11 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 }
             }
         }
-        if (crashMaskData && crashMaskCount === 0 && debugMaskData) {
-            for (let i = 0; i < debugMaskData.length; i++) {
-                if (debugMaskData[i] !== 0) {
+        if (crashMaskData && crashMaskCount === 0) {
+            for (let i = 0; i < crashMaskData.length; i++) {
+                const allowDebug = !debugMaskData || debugMaskData[i] !== 0;
+                const allowNoise = !noiseMaskData || noiseMaskData[i] !== 0;
+                if (allowDebug && allowNoise && crashMaskData[i] === 0) {
                     crashMaskData[i] = 255;
                     crashMaskCount++;
                 }
@@ -545,10 +618,26 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                         data[idx + 3] = 0;
                         continue;
                     }
+                    if (noiseMaskData && noiseMaskData[baseIndex] === 0) {
+                        data[idx] = 0;
+                        data[idx + 1] = 0;
+                        data[idx + 2] = 0;
+                        data[idx + 3] = 0;
+                        continue;
+                    }
+                    const maskAlpha = noiseMaskData ? Math.max(0, Math.min(1, noiseMaskData[baseIndex] / 255)) : 1;
+                    const finalAlpha = Math.max(0, Math.min(255, Math.round(srcAlpha * maskAlpha)));
+                    if (finalAlpha <= 0) {
+                        data[idx] = 0;
+                        data[idx + 1] = 0;
+                        data[idx + 2] = 0;
+                        data[idx + 3] = 0;
+                        continue;
+                    }
                     data[idx] = _voronoiCopy[idx];
                     data[idx + 1] = _voronoiCopy[idx + 1];
                     data[idx + 2] = _voronoiCopy[idx + 2];
-                    data[idx + 3] = srcAlpha;
+                    data[idx + 3] = finalAlpha;
                     fallbackHits++;
                 }
             }
@@ -557,7 +646,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
                 crashMaskData.fill(0);
                 crashMaskCount = 0;
                 for (let i = 0; i < debugMaskData.length; i++) {
-                    if (debugMaskData[i] !== 0) {
+                    if (debugMaskData[i] !== 0 && (!noiseMaskData || noiseMaskData[i] !== 0)) {
                         crashMaskData[i] = 255;
                         crashMaskCount++;
                     }
@@ -597,6 +686,14 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
             minX,
             minY,
             quality,
+            activeBucketIds: activeBuckets ? Array.from(activeBuckets) : undefined,
+        };
+    }
+    if (noiseMaskData && noiseMaskHits > 0) {
+        out.noiseMask = {
+            data: noiseMaskData,
+            width,
+            height,
         };
     }
     if (crashMaskData) {

--- a/src/tools/noiseMask.ts
+++ b/src/tools/noiseMask.ts
@@ -1,7 +1,7 @@
 import { Noise } from 'noisejs';
-import { fbmNoise as _fbmNoise } from './crackGenerator';
+import { sampleWarpedNoise } from '../lib/noiseField';
 
-export interface FbmMaskOptions {
+export interface NoiseMaskOptions {
     width: number;
     height: number;
     minX: number;
@@ -20,10 +20,10 @@ export interface FbmMaskOptions {
 }
 
 /**
- * Generate a binary (0/255) mask using the same FBM bucket strategy used by the
- * crack generator. Returns a Uint8Array of length width*height where 255 = allowed.
+ * Generate a binary (0/255) mask using the same warped-noise bucket strategy used by
+ * the crack generator. Returns a Uint8Array of length width*height where 255 = allowed.
  */
-export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
+export function generateNoiseMask(opts: NoiseMaskOptions): Uint8Array {
     const width = Math.max(1, Math.round(opts.width));
     const height = Math.max(1, Math.round(opts.height));
     const seed = (typeof opts.seed === 'number') ? (opts.seed >>> 0) : (Date.now() >>> 0);
@@ -49,7 +49,7 @@ export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
             const sampleY = ((ry + 0.5) / regionH) * height;
             const screenPt = { x: sampleX + (opts.minX || 0), y: sampleY + (opts.minY || 0) };
             const worldPt = (opts.mode === 'isometric') ? { x: screenPt.x, y: screenPt.y } : (opts.isoToWorld ? opts.isoToWorld(screenPt) : screenPt);
-            const v = _fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+            const v = sampleWarpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
             let id = Math.floor(v * buckets);
             if (id < 0) id = 0;
             if (id >= buckets) id = buckets - 1;
@@ -109,14 +109,14 @@ export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
             const noiseInst = bucketNoise[bucketId];
             const samplePt = { x: x + 0.5 + (opts.minX || 0), y: y + 0.5 + (opts.minY || 0) };
             const worldPt = (opts.mode === 'isometric') ? { x: samplePt.x, y: samplePt.y } : (opts.isoToWorld ? opts.isoToWorld(samplePt) : samplePt);
-            const baseVal = _fbmNoise(noiseInst, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+            const baseVal = sampleWarpedNoise(noiseInst, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
             const dist = Math.abs(baseVal - bucketCenters[bucketId]);
             if (dist > crackBandWidth) {
                 mask[y * width + x] = 0;
                 continue;
             }
             const edge = Math.max(0, (crackBandWidth - dist) / crackBandWidth);
-            const fine = _fbmNoise(noiseInst, worldPt.x * fineScales[bucketId] * 3.0, worldPt.y * fineScales[bucketId] * 3.0, 2, 2, 0.6);
+            const fine = sampleWarpedNoise(noiseInst, worldPt.x * fineScales[bucketId] * 3.0, worldPt.y * fineScales[bucketId] * 3.0, 2, 2, 0.6);
             const modulation = Math.max(0, Math.min(1, Math.pow(edge, 1.2) * (0.35 + 0.65 * fine)));
             const keep = modulation > 0.03; // threshold similar to alpha < 12
             mask[y * width + x] = keep ? 255 : 0;
@@ -126,7 +126,7 @@ export function generateFbmMask(opts: FbmMaskOptions): Uint8Array {
     return mask;
 }
 
-export interface FbmRegion {
+export interface NoiseRegion {
     map: Uint8Array;
     w: number;
     h: number;
@@ -137,7 +137,7 @@ export interface FbmRegion {
  * Generate the coarse bucket region map (values 0..buckets-1) without per-pixel
  * band filtering. Useful for visual debugging.
  */
-export function generateFbmRegionMap(opts: FbmMaskOptions): FbmRegion {
+export function generateNoiseRegionMap(opts: NoiseMaskOptions): NoiseRegion {
     const width = Math.max(1, Math.round(opts.width));
     const height = Math.max(1, Math.round(opts.height));
     const seed = (typeof opts.seed === 'number') ? (opts.seed >>> 0) : (Date.now() >>> 0);
@@ -158,7 +158,7 @@ export function generateFbmRegionMap(opts: FbmMaskOptions): FbmRegion {
             const sampleY = ((ry + 0.5) / regionH) * height;
             const screenPt = { x: sampleX + (opts.minX || 0), y: sampleY + (opts.minY || 0) };
             const worldPt = (opts.mode === 'isometric') ? { x: screenPt.x, y: screenPt.y } : (opts.isoToWorld ? opts.isoToWorld(screenPt) : screenPt);
-            const v = _fbmNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
+            const v = sampleWarpedNoise(regionNoise, worldPt.x * baseScale, worldPt.y * baseScale, octaves, lacunarity, gain);
             let id = Math.floor(v * buckets);
             if (id < 0) id = 0;
             if (id >= buckets) id = buckets - 1;
@@ -172,7 +172,7 @@ export function generateFbmRegionMap(opts: FbmMaskOptions): FbmRegion {
  * Convert a coarse region map to a visual RGBA image stretched to target width/height.
  * Each bucket gets a simple color; colors are deterministic but arbitrary for debugging.
  */
-export function regionMapToRgbaImage(region: FbmRegion, targetW: number, targetH: number): Uint8ClampedArray {
+export function regionMapToRgbaImage(region: NoiseRegion, targetW: number, targetH: number): Uint8ClampedArray {
     const out = new Uint8ClampedArray(targetW * targetH * 4);
     // simple color palette (repeatable)
     const palette: [number, number, number][] = [


### PR DESCRIPTION
## Summary
- build a per-pixel warped-noise mask inside the crack raster generator, intersect it with the debug road mask, and expose it for debugging
- render the generated noise mask alongside bucket delimitations in the game canvas overlay with alpha-weighted fills
- widen and ease the crack coverage slider to control larger bands and adjust the default crack band width

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc88e1decc832a933363c833157d26