### PR TITLE
Adjust crack width scaling to road size

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -2089,6 +2089,10 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
             try { console.debug('[GameCanvas] crack overlay -> procedural=', useProceduralCracks, 'hasTexture=', !!textureFromProps, 'allowTexture=', allowTexture); } catch (e) {}
             if (shouldRenderCracks) {
                 const polys: { x: number; y: number }[][] = [];
+                let roadWidthSum = 0;
+                let roadWidthCount = 0;
+                let roadWidthMin = Infinity;
+                let roadWidthMax = 0;
                 let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
                 segments.forEach(segment => {
                     const w = segment.width;
@@ -2103,6 +2107,13 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                     const p4 = { x: eW0.x + nx * (w / 2), y: eW0.y + ny * (w / 2) };
                     const poly = [p1, p2, p3, p4].map(pt => worldToIso(pt));
                     if (poly.length > 2) {
+                        const widthPx = Math.hypot(poly[0].x - poly[1].x, poly[0].y - poly[1].y);
+                        if (Number.isFinite(widthPx) && widthPx > 0.0001) {
+                            roadWidthSum += widthPx;
+                            roadWidthCount++;
+                            if (widthPx < roadWidthMin) roadWidthMin = widthPx;
+                            if (widthPx > roadWidthMax) roadWidthMax = widthPx;
+                        }
                         polys.push(poly);
                         poly.forEach(p => {
                             minX = Math.min(minX, p.x); minY = Math.min(minY, p.y);
@@ -2110,6 +2121,11 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                         });
                     }
                 });
+                const roadWidthStats = roadWidthCount > 0 ? {
+                    avg: roadWidthSum / roadWidthCount,
+                    min: roadWidthMin === Infinity ? roadWidthSum / roadWidthCount : roadWidthMin,
+                    max: roadWidthMax > 0 ? roadWidthMax : roadWidthSum / roadWidthCount,
+                } : null;
                 if (isFinite(minX) && isFinite(minY) && maxX > minX && maxY > minY) {
                     const defaultPadding = ((config as any).render?.crackMaskPaddingDefault ?? 4) as number;
                     const extraPadding = ((config as any).render?.crackMaskPaddingExtra ?? 8) as number;
@@ -2160,6 +2176,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                             minY,
                             renderConfig: renderCfg,
                             isoToWorld,
+                            roadWidthStats: roadWidthStats ?? undefined,
                         });
                         if (raster) {
                         let hasActiveHighlight = false;

--- a/src/tools/crackGenerator.ts
+++ b/src/tools/crackGenerator.ts
@@ -193,6 +193,11 @@ export interface CrackRasterOptions {
     minY: number;
     renderConfig: any;
     isoToWorld: (point: { x: number; y: number }) => { x: number; y: number };
+    roadWidthStats?: {
+        min: number;
+        max: number;
+        avg: number;
+    };
 }
 
 export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | null {
@@ -203,6 +208,7 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
         minY,
         renderConfig,
         isoToWorld,
+        roadWidthStats,
     } = options;
     const width = Math.max(1, Math.round(widthRaw));
     const height = Math.max(1, Math.round(heightRaw));
@@ -223,6 +229,10 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
         canvasH = Math.max(1, Math.round(height * quality));
     };
     recomputeCanvasSize();
+
+    const avgRoadWidthPx = (roadWidthStats && Number.isFinite(roadWidthStats.avg) && roadWidthStats.avg > 0)
+        ? roadWidthStats.avg
+        : null;
 
     const applyQualityReduction = (factor: number) => {
         if (!(factor > 1)) return;
@@ -336,8 +346,30 @@ export function generateCrackRaster(options: CrackRasterOptions): CrackRaster | 
 
     const seed = Math.floor((renderConfig?.crackSeed ?? Date.now())) >>> 0;
     const divisions = (typeof crackCfg.divisions === 'number' && crackCfg.divisions > 0) ? crackCfg.divisions : 400;
-    const thickness = (typeof crackCfg.thickness === 'number' && crackCfg.thickness > 0) ? crackCfg.thickness : 6;
-    const dilateRadius = (typeof crackCfg.dilateRadius === 'number' && crackCfg.dilateRadius >= 0) ? crackCfg.dilateRadius : 2;
+    let thickness = (typeof crackCfg.thickness === 'number' && crackCfg.thickness > 0) ? crackCfg.thickness : 6;
+    let dilateRadius = (typeof crackCfg.dilateRadius === 'number' && crackCfg.dilateRadius >= 0) ? crackCfg.dilateRadius : 2;
+
+    if (avgRoadWidthPx != null && isFinite(quality) && quality > 0) {
+        const baseCorePx = (thickness / 10) * quality;
+        const baseDilatePx = dilateRadius * quality;
+        const baseWidthPx = baseCorePx + 2 * baseDilatePx;
+        const minTargetPx = Math.max(0.9, avgRoadWidthPx * 0.18);
+        const minRoadWidthPx = (roadWidthStats && Number.isFinite(roadWidthStats.min) && roadWidthStats.min > 0)
+            ? roadWidthStats.min
+            : null;
+        const narrowLimitPx = minRoadWidthPx != null ? Math.max(0.8, minRoadWidthPx * 0.6) : Infinity;
+        const maxTargetPx = Math.max(minTargetPx, Math.min(4.5, avgRoadWidthPx * 0.5, narrowLimitPx));
+        const targetWidthPx = Math.max(minTargetPx, Math.min(maxTargetPx, avgRoadWidthPx * 0.35));
+        if (isFinite(baseWidthPx) && baseWidthPx > 0 && baseWidthPx > targetWidthPx) {
+            const clampedTarget = Math.max(minTargetPx, Math.min(maxTargetPx, targetWidthPx));
+            let corePx = Math.max(0.4, Math.min(baseCorePx, clampedTarget));
+            if (corePx > clampedTarget) corePx = clampedTarget;
+            const remainingPx = Math.max(0, clampedTarget - corePx);
+            const dilatePx = remainingPx / 2;
+            thickness = Math.max(1, (corePx / quality) * 10);
+            dilateRadius = Math.max(0, dilatePx / quality);
+        }
+    }
 
     const data = generateVoronoiCrackImage(canvasW, canvasH, {
         divisions,


### PR DESCRIPTION
## Summary
- collect per-road width statistics when building the crack mask to capture typical street thickness
- scale procedural crack thickness and dilation using the measured road widths so cracks stay proportional to the streets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd72a6bb1c832a87bb91b329d554dd